### PR TITLE
Tune defaults

### DIFF
--- a/client.go
+++ b/client.go
@@ -32,8 +32,8 @@ import (
 var (
 	// Default retry configuration
 	defaultRetryWaitMin = 1 * time.Second
-	defaultRetryWaitMax = 5 * time.Minute
-	defaultRetryMax     = 32
+	defaultRetryWaitMax = 30 * time.Second
+	defaultRetryMax     = 4
 
 	// defaultClient is used for performing requests without explicitly making
 	// a new client. It is purposely private to avoid modifications.

--- a/client_test.go
+++ b/client_test.go
@@ -260,7 +260,7 @@ func TestClient_RequestLogHook(t *testing.T) {
 }
 
 func TestClient_ResponseLogHook(t *testing.T) {
-	passAfter := time.Now().Add(time.Second)
+	passAfter := time.Now().Add(100 * time.Millisecond)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if time.Now().After(passAfter) {
 			w.WriteHeader(200)
@@ -276,8 +276,9 @@ func TestClient_ResponseLogHook(t *testing.T) {
 
 	client := NewClient()
 	client.Logger = log.New(buf, "", log.LstdFlags)
-	client.RetryWaitMin = 100 * time.Millisecond
-	client.RetryWaitMax = 100 * time.Millisecond
+	client.RetryWaitMin = 10 * time.Millisecond
+	client.RetryWaitMax = 10 * time.Millisecond
+	client.RetryMax = 15
 	client.ResponseLogHook = func(logger *log.Logger, resp *http.Response) {
 		if resp.StatusCode == 200 {
 			// Log something when we get a 200


### PR DESCRIPTION
The defaults in `retryablehttp` try absurdly hard to get a good status out of an HTTP server. Since calls are blocking, this often creates an issue where a ton of time passes while waiting to retry, especially with the exponential growth and max waiting period at 5 minutes by default. This PR intends to hone these values in to satisfy the 90% use case, while still allowing configuration to override for the other 10% of cases.

Example of what this would look like with the defaults before:

```
~ » time go run test.go
2016/09/29 17:36:10 [DEBUG] GET http://httpstat.us/500
2016/09/29 17:36:10 [DEBUG] GET http://httpstat.us/500 (status: 500): retrying in 1s (32 left)
2016/09/29 17:36:11 [DEBUG] GET http://httpstat.us/500 (status: 500): retrying in 2s (31 left)
2016/09/29 17:36:13 [DEBUG] GET http://httpstat.us/500 (status: 500): retrying in 4s (30 left)
2016/09/29 17:36:17 [DEBUG] GET http://httpstat.us/500 (status: 500): retrying in 8s (29 left)
2016/09/29 17:36:26 [DEBUG] GET http://httpstat.us/500 (status: 500): retrying in 16s (28 left)
2016/09/29 17:36:42 [DEBUG] GET http://httpstat.us/500 (status: 500): retrying in 32s (27 left)
2016/09/29 17:37:14 [DEBUG] GET http://httpstat.us/500 (status: 500): retrying in 1m4s (26 left)

... you get the picture, this will take forever
```

And after:

```
~ » time go run test.go
2016/09/29 17:30:25 [DEBUG] GET http://httpstat.us/500
2016/09/29 17:30:25 [DEBUG] GET http://httpstat.us/500 (status: 500): retrying in 1s (4 left)
2016/09/29 17:30:26 [DEBUG] GET http://httpstat.us/500 (status: 500): retrying in 2s (3 left)
2016/09/29 17:30:28 [DEBUG] GET http://httpstat.us/500 (status: 500): retrying in 4s (2 left)
2016/09/29 17:30:32 [DEBUG] GET http://httpstat.us/500 (status: 500): retrying in 8s (1 left)
2016/09/29 17:30:41 [ERR] GET http://httpstat.us/500 giving up after 5 attempts

real	0m15.854s
user	0m0.435s
sys	0m0.111s
```

This changes the default behavior, which isn't great, but I feel like the defaults cause more chaos than they help avoid, especially in cases .

/cc @phinze