### PR TITLE
Don't retry on URL scheme and other non-retryable errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -142,11 +142,23 @@ func NewClient() *Client {
 	}
 }
 
+type temporary interface {
+	Temporary() bool
+}
+
 // DefaultRetryPolicy provides a default callback for Client.CheckRetry, which
 // will retry on connection errors and server errors.
 func DefaultRetryPolicy(resp *http.Response, err error) (bool, error) {
 	if err != nil {
-		return true, err
+		retryable := true
+		switch t := err.(type) {
+		// net.Error and url.Error have a Temporary() bool that tells us if their
+		// errors are retryable, rather than typecheck for the specific error
+		// classes, we just use that same interface
+		case temporary:
+			retryable = t.Temporary()
+		}
+		return retryable, err
 	}
 	// Check the response code. We retry on 500-range responses to allow
 	// the server time to recover, as 500's are typically not permanent
@@ -184,7 +196,7 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 		checkOK, checkErr := c.CheckRetry(resp, err)
 
 		if err != nil {
-			c.Logger.Printf("[ERR] %s %s request failed: %v", req.Method, req.URL, err)
+			c.Logger.Printf("[ERR] %s %s request failed: %v (%T)", req.Method, req.URL, err, err)
 		} else {
 			// Call this here to maintain the behavior of logging all requests,
 			// even if CheckRetry signals to stop.


### PR DESCRIPTION
In scenarios with bad URLs like "not/a/uri", the default retry policy
was retrying even though the problem would never go away.

Turns out net.Error and url.Error have a `Temporary() bool` interface
they used to indicate whether or not they are retryable.

By checking for and respecting this interface, we can skip retries when
they are not going to make any difference.