### PR TITLE
extract status code for logging

### DIFF
--- a/client.go
+++ b/client.go
@@ -200,6 +200,9 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 
 		// Attempt the request
 		resp, err := c.HTTPClient.Do(req.Request)
+		if resp != nil {
+			code = resp.StatusCode
+		}
 
 		// Check if we should continue with retries.
 		checkOK, checkErr := c.CheckRetry(resp, err)


### PR DESCRIPTION
It's currently only used for logging later on, but because it's never set, the log never includes the response code (used by https://github.com/hashicorp/go-retryablehttp/blob/master/client.go#L237-L239)