### PR TITLE
Add Request.WithContext method

### DIFF
--- a/client.go
+++ b/client.go
@@ -74,6 +74,8 @@ type Request struct {
 	*http.Request
 }
 
+// WithContext returns wrapped Request with a shallow copy of underlying *http.Request
+// with its context changed to ctx. The provided ctx must be non-nil.
 func (r *Request) WithContext(ctx context.Context) *Request {
 	r.Request = r.Request.WithContext(ctx)
 	return r

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package retryablehttp
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -361,6 +362,40 @@ func TestClient_ResponseLogHook(t *testing.T) {
 	}
 	if !strings.Contains(out, "test_500_body") {
 		t.Fatalf("expect response callback on 500: %q", out)
+	}
+}
+
+func TestClient_RequestWithContext(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("test_200_body"))
+	}))
+	defer ts.Close()
+
+	req, err := NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	ctx, cancel := context.WithCancel(req.Request.Context())
+	req = req.WithContext(ctx)
+
+	client := NewClient()
+
+	called := 0
+	client.CheckRetry = func(resp *http.Response, err error) (bool, error) {
+		called++
+		return DefaultRetryPolicy(resp, err)
+	}
+
+	cancel()
+	_, err = client.Do(req)
+
+	if called != 0 {
+		t.Fatalf("CheckRetry called %d times, expected 1", called)
+	}
+
+	if !strings.Contains(err.Error(), "context") {
+		t.Fatalf("Expected context err, got:%v", err)
 	}
 }
 


### PR DESCRIPTION
Calling WithContext on wrapped [Request](https://godoc.org/github.com/hashicorp/go-retryablehttp#Request), would return *http.Request, so user cannot do:

```go
req, err := NewRequest(http.MethodGet, ts.URL, nil)
if err != nil { /* handle error */ }
ctx, cancel := context.WithCancel(req.Request.Context())
req = req.WithContext(ctx) // compile time error here
```

This pull request, fixes #22.