### PR TITLE
Drop request wrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 go:
-  - 1.8.1
+  - 1.9
 
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ The main difference from `net/http` is that requests which take a request body
 request body to be "rewound" if the initial request fails so that the full
 request can be attempted again.
 
+In order to try the same request multiple times, `retryablehttp` may need to
+read the request body multiple times. If the body passed to `Client.Do`
+implements [io.Seeker](`https://golang.org/pkg/io/#Seeker`), then this is
+achieved by rewinding the reader via a call to `Seek(0, 0)` on each retry. If
+the body does not implement `io.Seeker` then its contents will be read to an
+internal buffer just once, before the first attempt. Note that `io.Seeker` is
+implemented by `bytes.Buffer`, `bytes.Reader`, `strings.Reader`, `os.File`, and
+many other common sources for request bodies.
+
 Example Use
 ===========
 


### PR DESCRIPTION
This fixes #22 in a different way to the current proposed fix (#21):
- Do() can now take any http.Request as input. If the request body is not seekable then the contents of the request are read to a buffer, and `bytes.Reader` is used, which is seekable.
  - but if the request body is _already_ seekable then the copy is not made
  - and in my experience almost all request bodies are already in-memory buffers created by marshaling json / xml / text / etc, so I don't think this is a big loss
  - and realistically, if the user passes in a request body that was not seekable, then under the old API the user just would have done the in-memory copy trick anyway
  - so it really does not seem like we're losing a lot here
- drops the Request wrapper struct (converts it to a type alias for http.Request for backwards compatbility)
- the `NewRequest` function is now just a direct passthrough to `http.newRequest`

One of the nice things about this approach is that it allows users of this library to define interfaces that can match both `http.Client` and `retryablehttp.Client`, so e.g. that retryable HTTP requests can be dependency-injected into applications:
```
type MyHttpClient interface {
  Do(req *http.Request) (*http.Response, error)
}

func doSomething(client MyHttpClient) { ... }

func main() {
  if (shouldBeRetryable) {
    doSomething(&retryablehttp.Client{...})
  } else {
   doSomething(&http.Client{...})
  }
}
```