### PR TITLE
Allow various types of input to avoid racy seeking

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,16 @@ makes `retryablehttp` very easy to drop into existing programs.
 
 `retryablehttp` performs automatic retries under certain conditions. Mainly, if
 an error is returned by the client (connection errors, etc.), or if a 500-range
-response code is received, then a retry is invoked after a wait period.
-Otherwise, the response is returned and left to the caller to interpret.
+response code is received (except 501), then a retry is invoked after a wait
+period.  Otherwise, the response is returned and left to the caller to
+interpret.
 
 The main difference from `net/http` is that requests which take a request body
-(POST/PUT et. al) require an `io.ReadSeeker` to be provided. This enables the
-request body to be "rewound" if the initial request fails so that the full
-request can be attempted again.
+(POST/PUT et. al) can have the body provided in a number of ways (some more or
+less efficient) that allow "rewinding" the request body if the initial request
+fails so that the full request can be attempted again. See the
+[godoc](http://godoc.org/github.com/hashicorp/go-retryablehttp) for more
+details.
 
 Example Use
 ===========

--- a/client_test.go
+++ b/client_test.go
@@ -74,6 +74,10 @@ func (c *custReader) Read(p []byte) (n int, err error) {
 func TestClient_Do(t *testing.T) {
 	testBytes := []byte("hello")
 	// Native func
+	testClient_Do(t, ReaderFunc(func() (io.Reader, error) {
+		return bytes.NewReader(testBytes), nil
+	}))
+	// Native func, different Go type
 	testClient_Do(t, func() (io.Reader, error) {
 		return bytes.NewReader(testBytes), nil
 	})

--- a/client_test.go
+++ b/client_test.go
@@ -3,6 +3,7 @@ package retryablehttp
 import (
 	"bytes"
 	"errors"
+	"io"
 	"io/ioutil"
 	"log"
 	"net"
@@ -48,9 +49,48 @@ func TestRequest(t *testing.T) {
 	}
 }
 
+// Since normal ways we would generate a Reader have special cases, use a
+// custom type here
+type custReader struct {
+	val string
+	pos int
+}
+
+func (c *custReader) Read(p []byte) (n int, err error) {
+	if c.val == "" {
+		c.val = "hello"
+	}
+	if c.pos >= len(c.val) {
+		return 0, io.EOF
+	}
+	var i int
+	for i = 0; i < len(p) && i+c.pos < len(c.val); i++ {
+		p[i] = c.val[i+c.pos]
+	}
+	c.pos += i
+	return i, nil
+}
+
 func TestClient_Do(t *testing.T) {
+	testBytes := []byte("hello")
+	// Native func
+	testClient_Do(t, func() (io.Reader, error) {
+		return bytes.NewReader(testBytes), nil
+	})
+	// []byte
+	testClient_Do(t, testBytes)
+	// *bytes.Buffer
+	testClient_Do(t, bytes.NewBuffer(testBytes))
+	// *bytes.Reader
+	testClient_Do(t, bytes.NewReader(testBytes))
+	// io.ReadSeeker
+	testClient_Do(t, strings.NewReader(string(testBytes)))
+	// io.Reader
+	testClient_Do(t, &custReader{})
+}
+
+func testClient_Do(t *testing.T, body interface{}) {
 	// Create a request
-	body := bytes.NewReader([]byte("hello"))
 	req, err := NewRequest("PUT", "http://127.0.0.1:28934/v1/foo", body)
 	if err != nil {
 		t.Fatalf("err: %v", err)


### PR DESCRIPTION
With the previous code, some data races have very occasionally been
observed in client code due to the seek call (the write) and a read call
that is likely coming from deep in the bowels of the net/http package as
for HTTP/2 connections the request body reads happen in goroutines since
it's multiplexed. The exact cause is not yet known, but the same
behavior has not been observed in Pester, which copies the request body
anew each time instead of seeking. Even if there is not technically any
concurrent modification, a read after an out-of-order seek can mean
unexpected data can be read.

This eliminates that possibility in many cases by taking advantage of
the fact that we always seek to the first byte and simply eliminating
the need for seeks entirely when possible, instead using new readers
over the same underlying byte slice.

We accept various different ways of inputting the data and try to do the
right thing in all cases. io.ReadSeeker is still supported (but
potentially racy).