### PR TITLE
Revert "Use a math.Rand variable for pseudo-random numbers"

### DIFF
--- a/client.go
+++ b/client.go
@@ -49,9 +49,6 @@ var (
 	// a new client. It is purposely private to avoid modifications.
 	defaultClient = NewClient()
 
-	// random is used to generate pseudo-random numbers.
-	random = rand.New(rand.NewSource(time.Now().UnixNano()))
-
 	// We need to consume response bodies to maintain http connections, but
 	// limit the size we consume to respReadLimit.
 	respReadLimit = int64(4096)
@@ -328,11 +325,14 @@ func LinearJitterBackoff(min, max time.Duration, attemptNum int, resp *http.Resp
 		return min * time.Duration(attemptNum)
 	}
 
+	// Seed rand; doing this every time is fine
+	rand := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
+
 	// Pick a random number that lies somewhere between the min and max and
 	// multiply by the attemptNum. attemptNum starts at zero so we always
 	// increment here. We first get a random percentage, then apply that to the
 	// difference between min and max, and add to min.
-	jitter := random.Float64() * float64(max-min)
+	jitter := rand.Float64() * float64(max-min)
 	jitterMin := int64(jitter) + int64(min)
 	return time.Duration(jitterMin * int64(attemptNum))
 }


### PR DESCRIPTION
Reverts hashicorp/go-retryablehttp#33

As discussed in #35 and #38, reverting this until someone implements a suitable saferand package.