### PR TITLE
Use cleanhttp.DefaultPooledConnection and enforce cleanup

### DIFF
--- a/client.go
+++ b/client.go
@@ -277,7 +277,7 @@ type Client struct {
 // NewClient creates a new Client with default settings.
 func NewClient() *Client {
 	return &Client{
-		HTTPClient:   cleanhttp.DefaultClient(),
+		HTTPClient:   cleanhttp.DefaultPooledClient(),
 		Logger:       log.New(os.Stderr, "", log.LstdFlags),
 		RetryWaitMin: defaultRetryWaitMin,
 		RetryWaitMax: defaultRetryWaitMax,
@@ -368,6 +368,10 @@ func PassthroughErrorHandler(resp *http.Response, err error, _ int) (*http.Respo
 
 // Do wraps calling an HTTP method with retries.
 func (c *Client) Do(req *Request) (*http.Response, error) {
+	if c.HTTPClient == nil {
+		c.HTTPClient = cleanhttp.DefaultPooledClient()
+	}
+
 	if c.Logger != nil {
 		c.Logger.Printf("[DEBUG] %s %s", req.Method, req.URL)
 	}
@@ -382,6 +386,7 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 		if req.body != nil {
 			body, err := req.body()
 			if err != nil {
+				c.HTTPClient.CloseIdleConnections()
 				return resp, err
 			}
 			if c, ok := body.(io.ReadCloser); ok {
@@ -422,6 +427,7 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 			if checkErr != nil {
 				err = checkErr
 			}
+			c.HTTPClient.CloseIdleConnections()
 			return resp, err
 		}
 
@@ -447,12 +453,14 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 		}
 		select {
 		case <-req.Context().Done():
+			c.HTTPClient.CloseIdleConnections()
 			return nil, req.Context().Err()
 		case <-time.After(wait):
 		}
 	}
 
 	if c.ErrorHandler != nil {
+		c.HTTPClient.CloseIdleConnections()
 		return c.ErrorHandler(resp, err, c.RetryMax+1)
 	}
 
@@ -461,6 +469,7 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 	if resp != nil {
 		resp.Body.Close()
 	}
+	c.HTTPClient.CloseIdleConnections()
 	return nil, fmt.Errorf("%s %s giving up after %d attempts",
 		req.Method, req.URL, c.RetryMax+1)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/hashicorp/go-retryablehttp
 
-require github.com/hashicorp/go-cleanhttp v0.5.0
+require github.com/hashicorp/go-cleanhttp v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
-github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=


### PR DESCRIPTION
This allows reuse of the existing connection on retries, since they're
going to the same host, but we explicitly close idle connections to
ensure they don't stick around forever after the series of requests is
done.

Fixes #44