### PR TITLE
adds debug and error methods to logger interface

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -355,7 +354,7 @@ func TestClient_ResponseLogHook(t *testing.T) {
 	buf := new(bytes.Buffer)
 
 	client := NewClient()
-	client.Logger = log.New(buf, "", log.LstdFlags)
+	client.Logger = newStdLogger(buf)
 	client.RetryWaitMin = 10 * time.Millisecond
 	client.RetryWaitMax = 10 * time.Millisecond
 	client.RetryMax = 15


### PR DESCRIPTION
This change makes it easier to use a different log implementation and use the log level from these loggers. I left out other additional ones (Infof, etc) since they are not used here