### PR TITLE
Allow Logger value to use hclog or previous Logger interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -27,11 +27,14 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"math"
 	"math/rand"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
+	"sync"
 	"time"
 
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
@@ -223,7 +226,19 @@ func NewRequest(method, url string, rawBody interface{}) (*Request, error) {
 
 // Logger interface allows to use other loggers than
 // standard log.Logger.
-type Logger = hclog.Logger
+type Logger interface {
+	Printf(string, ...interface{})
+}
+
+// To adapt an hclog.Logger to Logger for use by the existing hook functions
+// without changing the API.
+type hookLogger struct {
+	logger hclog.Logger
+}
+
+func (h hookLogger) Printf(s string, args ...interface{}) {
+	h.logger.Info(fmt.Sprintf(s, args...))
+}
 
 // RequestLogHook allows a function to run before each retry. The HTTP
 // request which will be made, and the retry number (0 for the initial
@@ -263,7 +278,7 @@ type ErrorHandler func(resp *http.Response, err error, numTries int) (*http.Resp
 // like automatic retries to tolerate minor outages.
 type Client struct {
 	HTTPClient *http.Client // Internal HTTP client.
-	Logger     Logger       // Customer logger instance.
+	Logger     interface{}  // Customer logger instance. Can be either Logger or hclog.Logger
 
 	RetryWaitMin time.Duration // Minimum time to wait
 	RetryWaitMax time.Duration // Maximum time to wait
@@ -286,19 +301,40 @@ type Client struct {
 
 	// ErrorHandler specifies the custom error handler to use, if any
 	ErrorHandler ErrorHandler
+
+	loggerInit sync.Once
 }
 
 // NewClient creates a new Client with default settings.
 func NewClient() *Client {
 	return &Client{
 		HTTPClient:   cleanhttp.DefaultClient(),
-		Logger:       hclog.L(),
 		RetryWaitMin: defaultRetryWaitMin,
 		RetryWaitMax: defaultRetryWaitMax,
 		RetryMax:     defaultRetryMax,
 		CheckRetry:   DefaultRetryPolicy,
 		Backoff:      DefaultBackoff,
 	}
+}
+
+func (c *Client) logger() interface{} {
+	c.loggerInit.Do(func() {
+		if c.Logger == nil {
+			c.Logger = log.New(os.Stderr, "", log.LstdFlags)
+		} else {
+			switch c.Logger.(type) {
+			case Logger:
+				// ok
+			case hclog.Logger:
+				// ok
+			default:
+				// This should happen in dev when they are setting Logger and work on code, not in prod.
+				panic(fmt.Sprintf("invalid logger type passed, must be Logger or hclog.Logger, was %T", c.Logger))
+			}
+		}
+	})
+
+	return c.Logger
 }
 
 // DefaultRetryPolicy provides a default callback for Client.CheckRetry, which
@@ -382,8 +418,13 @@ func PassthroughErrorHandler(resp *http.Response, err error, _ int) (*http.Respo
 
 // Do wraps calling an HTTP method with retries.
 func (c *Client) Do(req *Request) (*http.Response, error) {
-	if c.Logger != nil {
-		c.Logger.Debug("performing request", "method", req.Method, "url", req.URL)
+	if c.logger() != nil {
+		switch v := c.logger().(type) {
+		case Logger:
+			v.Printf("[DEBUG] %s %s", req.Method, req.URL)
+		case hclog.Logger:
+			v.Debug("performing request", "method", req.Method, "url", req.URL)
+		}
 	}
 
 	var resp *http.Response
@@ -406,7 +447,14 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 		}
 
 		if c.RequestLogHook != nil {
-			c.RequestLogHook(c.Logger, req.Request, i)
+			switch v := c.logger().(type) {
+			case Logger:
+				c.RequestLogHook(v, req.Request, i)
+			case hclog.Logger:
+				c.RequestLogHook(hookLogger{v}, req.Request, i)
+			default:
+				c.RequestLogHook(nil, req.Request, i)
+			}
 		}
 
 		// Attempt the request
@@ -419,15 +467,27 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 		checkOK, checkErr := c.CheckRetry(req.Context(), resp, err)
 
 		if err != nil {
-			if c.Logger != nil {
-				c.Logger.Error("request failed", "error", err, "method", req.Method, "url", req.URL)
+			if c.logger() != nil {
+				switch v := c.logger().(type) {
+				case Logger:
+					v.Printf("[ERR] %s %s request failed: %v", req.Method, req.URL, err)
+				case hclog.Logger:
+					v.Error("request failed", "error", err, "method", req.Method, "url", req.URL)
+				}
 			}
 		} else {
 			// Call this here to maintain the behavior of logging all requests,
 			// even if CheckRetry signals to stop.
 			if c.ResponseLogHook != nil {
 				// Call the response logger function if provided.
-				c.ResponseLogHook(c.Logger, resp)
+				switch v := c.logger().(type) {
+				case Logger:
+					c.ResponseLogHook(v, resp)
+				case hclog.Logger:
+					c.ResponseLogHook(hookLogger{v}, resp)
+				default:
+					c.ResponseLogHook(nil, resp)
+				}
 			}
 		}
 
@@ -456,8 +516,13 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 		if code > 0 {
 			desc = fmt.Sprintf("%s (status: %d)", desc, code)
 		}
-		if c.Logger != nil {
-			c.Logger.Debug("retrying request", "request", desc, "timeout", wait, "remaining", remain)
+		if c.logger() != nil {
+			switch v := c.logger().(type) {
+			case Logger:
+				v.Printf("[DEBUG] %s: retrying in %s (%d left)", desc, wait, remain)
+			case hclog.Logger:
+				v.Debug("retrying request", "request", desc, "timeout", wait, "remaining", remain)
+			}
 		}
 		select {
 		case <-req.Context().Done():
@@ -484,8 +549,13 @@ func (c *Client) drainBody(body io.ReadCloser) {
 	defer body.Close()
 	_, err := io.Copy(ioutil.Discard, io.LimitReader(body, respReadLimit))
 	if err != nil {
-		if c.Logger != nil {
-			c.Logger.Error("error reading response body", "error", err)
+		if c.logger() != nil {
+			switch v := c.logger().(type) {
+			case Logger:
+				v.Printf("[ERR] error reading response body: %v", err)
+			case hclog.Logger:
+				v.Error("error reading response body", "error", err)
+			}
 		}
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -368,14 +368,14 @@ func TestClient_ResponseLogHook(t *testing.T) {
 	client.ResponseLogHook = func(logger Logger, resp *http.Response) {
 		if resp.StatusCode == 200 {
 			// Log something when we get a 200
-			logger.Info("test_log_pass")
+			logger.Printf("test_log_pass")
 		} else {
 			// Log the response body when we get a 500
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
-			logger.Info("request", "body", string(body))
+			logger.Printf("request", "body", string(body))
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,6 @@
 module github.com/hashicorp/go-retryablehttp
 
-require github.com/hashicorp/go-cleanhttp v0.5.0
+require (
+	github.com/hashicorp/go-cleanhttp v0.5.0
+	github.com/hashicorp/go-hclog v0.9.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,7 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
Related to #60 this changes the Logger to be hclog.Logger with the smallest API change possible.