### PR TITLE
feat: allow access to LogHooks with nil Logger

### DIFF
--- a/client.go
+++ b/client.go
@@ -457,13 +457,13 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 			}
 		}
 
-		if c.RequestLogHook != nil && logger != nil {
+		if c.RequestLogHook != nil {
 			switch v := logger.(type) {
 			case Logger:
 				c.RequestLogHook(v, req.Request, i)
 			case hclog.Logger:
 				c.RequestLogHook(hookLogger{v}, req.Request, i)
-			default:
+			case nil:
 				c.RequestLogHook(nil, req.Request, i)
 			}
 		}

--- a/client.go
+++ b/client.go
@@ -463,7 +463,7 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 				c.RequestLogHook(v, req.Request, i)
 			case hclog.Logger:
 				c.RequestLogHook(hookLogger{v}, req.Request, i)
-			case nil:
+			default:
 				c.RequestLogHook(nil, req.Request, i)
 			}
 		}
@@ -494,7 +494,7 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 					c.ResponseLogHook(v, resp)
 				case hclog.Logger:
 					c.ResponseLogHook(hookLogger{v}, resp)
-				case nil:
+				default:
 					c.ResponseLogHook(nil, resp)
 				}
 			}

--- a/client.go
+++ b/client.go
@@ -47,6 +47,9 @@ var (
 	defaultRetryWaitMax = 30 * time.Second
 	defaultRetryMax     = 4
 
+	// defaultLogger is the logger provided with defaultClient
+	defaultLogger = log.New(os.Stderr, "", log.LstdFlags)
+
 	// defaultClient is used for performing requests without explicitly making
 	// a new client. It is purposely private to avoid modifications.
 	defaultClient = NewClient()
@@ -309,7 +312,7 @@ type Client struct {
 func NewClient() *Client {
 	return &Client{
 		HTTPClient:   cleanhttp.DefaultPooledClient(),
-		Logger:       log.New(os.Stderr, "", log.LstdFlags),
+		Logger:       defaultLogger,
 		RetryWaitMin: defaultRetryWaitMin,
 		RetryWaitMax: defaultRetryWaitMax,
 		RetryMax:     defaultRetryMax,

--- a/client_test.go
+++ b/client_test.go
@@ -6,13 +6,11 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
-	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -298,7 +296,7 @@ func TestClient_Get(t *testing.T) {
 
 func TestClient_RequestLogHook(t *testing.T) {
 	t.Run("RequestLogHook called with default Logger", func(t *testing.T) {
-		testClient_RequestLogHook(t, log.New(os.Stderr, "", log.LstdFlags))
+		testClient_RequestLogHook(t, defaultLogger)
 	})
 	t.Run("RequestLogHook successfully called with nil Logger", func(t *testing.T) {
 		testClient_RequestLogHook(t, nil)

--- a/client_test.go
+++ b/client_test.go
@@ -295,7 +295,7 @@ func TestClient_Get(t *testing.T) {
 }
 
 func TestClient_RequestLogHook(t *testing.T) {
-	t.Run("RequestLogHook called with default Logger", func(t *testing.T) {
+	t.Run("RequestLogHook successfully called with default Logger", func(t *testing.T) {
 		testClient_RequestLogHook(t, defaultLogger)
 	})
 	t.Run("RequestLogHook successfully called with nil Logger", func(t *testing.T) {
@@ -351,6 +351,20 @@ func testClient_RequestLogHook(t *testing.T, logger interface{}) {
 }
 
 func TestClient_ResponseLogHook(t *testing.T) {
+	t.Run("ResponseLogHook successfully called with hclog Logger", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		l := hclog.New(&hclog.LoggerOptions{
+			Output: buf,
+		})
+		testClient_ResponseLogHook(t, l, buf)
+	})
+	t.Run("ResponseLogHook successfully called with nil Logger", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		testClient_ResponseLogHook(t, nil, buf)
+	})
+}
+
+func testClient_ResponseLogHook(t *testing.T, l interface{}, buf *bytes.Buffer) {
 	passAfter := time.Now().Add(100 * time.Millisecond)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if time.Now().After(passAfter) {
@@ -363,13 +377,7 @@ func TestClient_ResponseLogHook(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	buf := new(bytes.Buffer)
-
 	client := NewClient()
-
-	l := hclog.New(&hclog.LoggerOptions{
-		Output: buf,
-	})
 
 	client.Logger = l
 	client.RetryWaitMin = 10 * time.Millisecond
@@ -377,15 +385,25 @@ func TestClient_ResponseLogHook(t *testing.T) {
 	client.RetryMax = 15
 	client.ResponseLogHook = func(logger Logger, resp *http.Response) {
 		if resp.StatusCode == 200 {
+			successLog := "test_log_pass"
 			// Log something when we get a 200
-			logger.Printf("test_log_pass")
+			if logger != nil {
+				logger.Printf(successLog)
+			} else {
+				buf.WriteString(successLog)
+			}
 		} else {
 			// Log the response body when we get a 500
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
-			logger.Printf("request", "body", string(body))
+			failLog := string(body)
+			if logger != nil {
+				logger.Printf(failLog)
+			} else {
+				buf.WriteString(failLog)
+			}
 		}
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -295,6 +297,15 @@ func TestClient_Get(t *testing.T) {
 }
 
 func TestClient_RequestLogHook(t *testing.T) {
+	t.Run("RequestLogHook called with default Logger", func(t *testing.T) {
+		testClient_RequestLogHook(t, log.New(os.Stderr, "", log.LstdFlags))
+	})
+	t.Run("RequestLogHook successfully called with nil Logger", func(t *testing.T) {
+		testClient_RequestLogHook(t, nil)
+	})
+}
+
+func testClient_RequestLogHook(t *testing.T, logger interface{}) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
 			t.Fatalf("bad method: %s", r.Method)
@@ -310,6 +321,7 @@ func TestClient_RequestLogHook(t *testing.T) {
 	testURIPath := "/foo/bar"
 
 	client := NewClient()
+	client.Logger = logger
 	client.RequestLogHook = func(logger Logger, req *http.Request, retry int) {
 		retries = retry
 


### PR DESCRIPTION
# Summary

* Allow `RequestLogHook` and `ResponseLogHook` to be accessed even if the `client.Logger` is `nil`
* Add tests for ^

# Use Case

We're using a logging package that doesn't conform to `Logger` interface, but still want access to values available through `LogHook`s. Specifically,  we're using `RequestLogHook` to access the retry count and pass it to our own internal structured JSON logging package.

However, setting `Client.Logger = nil` (in order to suppress logging to STDOUT) skips the block of code where `RequestLogHook` accesses the retry count ([here](https://github.com/hashicorp/go-retryablehttp/blob/v0.6.2/client.go#L457)). The presence of the `default` case in the `switch` [here](https://github.com/hashicorp/go-retryablehttp/blob/v0.6.2/client.go#L463) makes me think that this behavior (suppressed logging, but still able to access values in `LogHook`s) was meant to be supported.

# Considered Alternatives

The alternative of disabling the logger with a noop logger or other similar approach has a small performance cost (see [here](https://stackoverflow.com/questions/10571182/how-to-disable-a-log-logger/34457930#34457930), tho the benchmarks are probably out of date, the idea that it will cost _something_ to have a noop logger is what is most important)