### PR TITLE
Errors from original http.Client response are double-wrapped when using the RoundTripper

### DIFF
--- a/roundtripper.go
+++ b/roundtripper.go
@@ -3,6 +3,7 @@ package retryablehttp
 import (
 	"errors"
 	"net/http"
+	"net/url"
 	"sync"
 )
 
@@ -41,7 +42,9 @@ func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// Execute the request.
 	resp, err := rt.Client.Do(retryableReq)
-	if errors.Unwrap(err) != nil {
+	// If we got an error returned by standard library's `Do` method, unwrap it
+	// otherwise we will wind up erroneously re-nesting the error.
+	if _, ok := err.(*url.Error); ok {
 		return resp, errors.Unwrap(err)
 	}
 

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -1,6 +1,7 @@
 package retryablehttp
 
 import (
+	"errors"
 	"net/http"
 	"sync"
 )
@@ -39,5 +40,10 @@ func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	// Execute the request.
-	return rt.Client.Do(retryableReq)
+	resp, err := rt.Client.Do(retryableReq)
+	if errors.Unwrap(err) != nil {
+		return resp, errors.Unwrap(err)
+	}
+
+	return resp, err
 }


### PR DESCRIPTION
When you're using a `http.Client` with a custom `RoundTripper` that actually facilitates the retries  (it maintains its own internal `http.Client` object); any errors returned from the original `http.Client` are re-wrapped.

For instance, trying to do a Get request that returns an error response, and using the PassthroughErrorHandler to return the real failure would result in an error like this: 

```
Get "http://this-url-does-not-exist.com/": Get "http://this-url-does-not-exist.com/": dial tcp: lookup this-url-does-not-exist.com: no such host
```

This is basically an `*url.Error` object nested within another `*url.Error`'s `Err` field. 

We can just `.Unwrap()` it to make sure that we only get what we need. Open to other suggestions though.