### PR TITLE
Added support for HTTP 429 Retry-After as per Issue #99

### DIFF
--- a/client.go
+++ b/client.go
@@ -445,7 +445,7 @@ func DefaultRetryPolicy(ctx context.Context, resp *http.Response, err error) (bo
 // by the provided minimum and maximum durations.
 func DefaultBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
 
-	if resp.StatusCode == 429 {
+	if resp.StatusCode == http.StatusTooManyRequests {
 		if s, ok := resp.Header["Retry-After"]; ok {
 			if sleep, err := strconv.ParseInt(s[0], 10, 32); err == nil {
 				return time.Duration(int64(time.Second) * sleep)

--- a/client.go
+++ b/client.go
@@ -494,7 +494,7 @@ func ErrorPropagatedRetryPolicy(ctx context.Context, resp *http.Response, err er
 // (HTTP Code 429) is found in the resp parameter. Hence it will return the number of
 // seconds the server states it may be ready to process more requests from this client.
 func DefaultBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
-	if nil != resp {
+	if resp != nil {
 		if resp.StatusCode == http.StatusTooManyRequests {
 			if s, ok := resp.Header["Retry-After"]; ok {
 				if sleep, err := strconv.ParseInt(s[0], 10, 32); err == nil {

--- a/client.go
+++ b/client.go
@@ -498,7 +498,7 @@ func DefaultBackoff(min, max time.Duration, attemptNum int, resp *http.Response)
 		if resp.StatusCode == http.StatusTooManyRequests {
 			if s, ok := resp.Header["Retry-After"]; ok {
 				if sleep, err := strconv.ParseInt(s[0], 10, 64); err == nil {
-					return time.Duration(int64(time.Second) * sleep)
+					return time.Second * time.Duration(sleep)
 				}
 			}
 		}

--- a/client.go
+++ b/client.go
@@ -490,11 +490,12 @@ func ErrorPropagatedRetryPolicy(ctx context.Context, resp *http.Response, err er
 // will perform exponential backoff based on the attempt number and limited
 // by the provided minimum and maximum durations.
 func DefaultBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
-
-	if resp.StatusCode == http.StatusTooManyRequests {
-		if s, ok := resp.Header["Retry-After"]; ok {
-			if sleep, err := strconv.ParseInt(s[0], 10, 32); err == nil {
-				return time.Duration(int64(time.Second) * sleep)
+	if nil != resp {
+		if resp.StatusCode == http.StatusTooManyRequests {
+			if s, ok := resp.Header["Retry-After"]; ok {
+				if sleep, err := strconv.ParseInt(s[0], 10, 32); err == nil {
+					return time.Duration(int64(time.Second) * sleep)
+				}
 			}
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -426,7 +426,7 @@ func DefaultRetryPolicy(ctx context.Context, resp *http.Response, err error) (bo
 		return true, nil
 	}
 
-	// 429 Too Many Request is recoverable. Sometimes the server puts
+	// 429 Too Many Requests is recoverable. Sometimes the server puts
 	// a Retry-After response header to indicate when the server is
 	// available to start processing request from client.
 	if resp.StatusCode == http.StatusTooManyRequests {

--- a/client.go
+++ b/client.go
@@ -489,6 +489,10 @@ func ErrorPropagatedRetryPolicy(ctx context.Context, resp *http.Response, err er
 // DefaultBackoff provides a default callback for Client.Backoff which
 // will perform exponential backoff based on the attempt number and limited
 // by the provided minimum and maximum durations.
+//
+// It also tries to parse Retry-After response header when a http.StatusTooManyRequests
+// (HTTP Code 409) is found in the resp parameter. Hence it will return the number of
+// seconds the server states it may be ready to process more requests from this client.
 func DefaultBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
 	if nil != resp {
 		if resp.StatusCode == http.StatusTooManyRequests {

--- a/client.go
+++ b/client.go
@@ -497,7 +497,7 @@ func DefaultBackoff(min, max time.Duration, attemptNum int, resp *http.Response)
 	if resp != nil {
 		if resp.StatusCode == http.StatusTooManyRequests {
 			if s, ok := resp.Header["Retry-After"]; ok {
-				if sleep, err := strconv.ParseInt(s[0], 10, 32); err == nil {
+				if sleep, err := strconv.ParseInt(s[0], 10, 64); err == nil {
 					return time.Duration(int64(time.Second) * sleep)
 				}
 			}

--- a/client.go
+++ b/client.go
@@ -491,7 +491,7 @@ func ErrorPropagatedRetryPolicy(ctx context.Context, resp *http.Response, err er
 // by the provided minimum and maximum durations.
 //
 // It also tries to parse Retry-After response header when a http.StatusTooManyRequests
-// (HTTP Code 409) is found in the resp parameter. Hence it will return the number of
+// (HTTP Code 429) is found in the resp parameter. Hence it will return the number of
 // seconds the server states it may be ready to process more requests from this client.
 func DefaultBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
 	if nil != resp {

--- a/client.go
+++ b/client.go
@@ -35,6 +35,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -421,6 +422,13 @@ func DefaultRetryPolicy(ctx context.Context, resp *http.Response, err error) (bo
 		return true, nil
 	}
 
+	// 429 Too Many Request is recoverable. Sometimes the server puts
+	// a Retry-After response header to indicate when the server is
+	// available to start processing request from client.
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return true, nil
+	}
+
 	// Check the response code. We retry on 500-range responses to allow
 	// the server time to recover, as 500's are typically not permanent
 	// errors and may relate to outages on the server side. This will catch
@@ -436,6 +444,15 @@ func DefaultRetryPolicy(ctx context.Context, resp *http.Response, err error) (bo
 // will perform exponential backoff based on the attempt number and limited
 // by the provided minimum and maximum durations.
 func DefaultBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
+
+	if resp.StatusCode == 429 {
+		if s, ok := resp.Header["Retry-After"]; ok {
+			if sleep, err := strconv.ParseInt(s[0], 10, 32); err == nil {
+				return time.Duration(int64(time.Second) * sleep)
+			}
+		}
+	}
+
 	mult := math.Pow(2, float64(attemptNum)) * float64(min)
 	sleep := time.Duration(mult)
 	if float64(sleep) != mult || sleep > max {

--- a/client_test.go
+++ b/client_test.go
@@ -546,7 +546,7 @@ func TestClient_DefaultBackoff429TooManyRequest(t *testing.T) {
 		t.Fatalf("expected no errors since retryable")
 	}
 
-	if true != retryable {
+	if !retryable {
 		t.Fatal("Since 429 is recoverable, the default policy shall return true")
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -536,7 +536,7 @@ func TestClient_DefaultBackoff429TooManyRequest(t *testing.T) {
 	retryable := false
 
 	client.CheckRetry = func(_ context.Context, resp *http.Response, err error) (bool, error) {
-		retryable, _ = DefaultRetryPolicy(context.TODO(), resp, err)
+		retryable, _ = DefaultRetryPolicy(context.Background(), resp, err)
 		retryAfter = DefaultBackoff(client.RetryWaitMin, client.RetryWaitMax, 1, resp)
 		return false, nil
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -550,7 +550,7 @@ func TestClient_DefaultBackoff429TooManyRequest(t *testing.T) {
 		t.Fatal("Since 429 is recoverable, the default policy shall return true")
 	}
 
-	if time.Second*2 != retryAfter {
+	if retryAfter != 2*time.Second {
 		t.Fatalf("The header Retry-After specified 2 seconds, and shall not be %d seconds", retryAfter/time.Second)
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestRequest(t *testing.T) {
@@ -519,13 +518,17 @@ func TestClient_DefaultBackoff429TooManyRequest(t *testing.T) {
 	}
 
 	_, err := client.Get(ts.URL)
-	assert.Equal(t, nil, err)
+	if err != nil {
+		t.Fatalf("expected no errors since retryable")
+	}
 
-	assert.Equal(t, true, retryable,
-		"Since 429 is recoverable, the default policy shall return true")
+	if true != retryable {
+		t.Fatal("Since 429 is recoverable, the default policy shall return true")
+	}
 
-	assert.Equal(t, time.Second*2, retryAfter,
-		"The header Retry-After specified 2 seconds, and shall not be %d seconds", retryAfter/time.Second)
+	if time.Second*2 != retryAfter {
+		t.Fatalf("The header Retry-After specified 2 seconds, and shall not be %d seconds", retryAfter/time.Second)
+	}
 }
 
 func TestClient_DefaultRetryPolicy_TLS(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -532,7 +532,7 @@ func TestClient_DefaultBackoff429TooManyRequest(t *testing.T) {
 
 	client := NewClient()
 
-	retryAfter := time.Duration(0)
+	var retryAfter time.Duration
 	retryable := false
 
 	client.CheckRetry = func(_ context.Context, resp *http.Response, err error) (bool, error) {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hashicorp/go-retryablehttp
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-hclog v0.9.2
+	github.com/stretchr/testify v1.2.2
 )
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/hashicorp/go-retryablehttp
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-hclog v0.9.2
-	github.com/stretchr/testify v1.2.2
 )
 
 go 1.13


### PR DESCRIPTION
This was added in DefaultPolicy and DefaultBackoff. The latter will
examine the Retry-After response header (if existant) and do a backoff
for the specified amount of time. Otherwise it will default to default
backoff behaviour. 

This addresses Issue #99.