### PR TITLE
Try to fix #94 by eliminating the contention with a new struct copy.

### DIFF
--- a/client.go
+++ b/client.go
@@ -678,6 +678,11 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 			return nil, req.Context().Err()
 		case <-time.After(wait):
 		}
+
+		// Make shallow copy of http Request so that we can modify its body
+		// without racing against the closeBody call in persistConn.writeLoop.
+		httpreq := *req.Request
+		req.Request = &httpreq
 	}
 
 	// this is the closest we have to success criteria


### PR DESCRIPTION
Here's a more recent race test failure using go 1.14.6:

```
WARNING: DATA RACE
Write at 0x00c000141240 by goroutine 40:
  github.com/hashicorp/vault/vendor/github.com/hashicorp/go-retryablehttp.(*Client).Do()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/go-retryablehttp/client.go:524 +0x1e62
  github.com/hashicorp/vault/vendor/github.com/hashicorp/vault/api.(*Client).RawRequestWithContext()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/vault/api/client.go:844 +0x79d
  github.com/hashicorp/vault/vendor/github.com/hashicorp/vault/api.(*Sys).Mount()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/vault/api/sys_mounts.go:47 +0x22a
  github.com/hashicorp/vault/command/server.prepareTestContainer.func2()
      /go/src/github.com/hashicorp/vault/command/server/server_seal_transit_acc_test.go:171 +0x295
  github.com/hashicorp/vault/vendor/github.com/cenkalti/backoff.RetryNotify()
      /go/src/github.com/hashicorp/vault/vendor/github.com/cenkalti/backoff/retry.go:37 +0xc8
  github.com/hashicorp/vault/vendor/github.com/cenkalti/backoff.Retry()
      /go/src/github.com/hashicorp/vault/vendor/github.com/cenkalti/backoff/retry.go:24 +0xeb
  github.com/hashicorp/vault/vendor/github.com/ory/dockertest.(*Pool).Retry()
      /go/src/github.com/hashicorp/vault/vendor/github.com/ory/dockertest/dockertest.go:387 +0x100
  github.com/hashicorp/vault/command/server.prepareTestContainer()
      /go/src/github.com/hashicorp/vault/command/server/server_seal_transit_acc_test.go:158 +0x963
  github.com/hashicorp/vault/command/server.TestTransitWrapper_Lifecycle()
      /go/src/github.com/hashicorp/vault/command/server/server_seal_transit_acc_test.go:19 +0x53
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1039 +0x1eb

Previous read at 0x00c000141240 by goroutine 60:
  net/http.(*Request).closeBody()
      /usr/local/go/src/net/http/request.go:1390 +0x4d0
  net/http.(*persistConn).writeLoop()
      /usr/local/go/src/net/http/transport.go:2296 +0x496

Goroutine 40 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1090 +0x700
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1334 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1039 +0x1eb
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1332 +0x527
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1249 +0x43f
  main.main()
      _testmain.go:76 +0x223

Goroutine 60 (finished) created at:
  net/http.(*Transport).dialConn()
      /usr/local/go/src/net/http/transport.go:1648 +0xc33
  net/http.(*Transport).dialConnFor()
      /usr/local/go/src/net/http/transport.go:1365 +0x14f
```