### PR TITLE
Replace http.Client with interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -71,6 +71,11 @@ var (
 	schemeErrorRe = regexp.MustCompile(`unsupported protocol scheme`)
 )
 
+type HTTPClient interface {
+	CloseIdleConnections()
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // ReaderFunc is the type of function that can be given natively to NewRequest
 type ReaderFunc func() (io.Reader, error)
 
@@ -314,7 +319,7 @@ type ResponseLogHook func(Logger, *http.Response)
 
 // CheckRetry specifies a policy for handling retries. It is called
 // following each request with the response and error values returned by
-// the http.Client. If CheckRetry returns false, the Client stops retrying
+// the HTTPClient. If CheckRetry returns false, the Client stops retrying
 // and returns the response to the caller. If CheckRetry returns an error,
 // that error value is returned in lieu of the error from the request. The
 // Client will close any response body when retrying, but if the retry is
@@ -336,8 +341,8 @@ type ErrorHandler func(resp *http.Response, err error, numTries int) (*http.Resp
 // Client is used to make HTTP requests. It adds additional functionality
 // like automatic retries to tolerate minor outages.
 type Client struct {
-	HTTPClient *http.Client // Internal HTTP client.
-	Logger     interface{}  // Customer logger instance. Can be either Logger or LeveledLogger
+	HTTPClient HTTPClient  // Internal HTTP client.
+	Logger     interface{} // Customer logger instance. Can be either Logger or LeveledLogger
 
 	RetryWaitMin time.Duration // Minimum time to wait
 	RetryWaitMax time.Duration // Maximum time to wait


### PR DESCRIPTION
### Changes
1) Created interface `HTTPClient` with functions `Do` and `CloseIdleConnections`
2) Replaced `HTTPClient` field type from `*http.Client` to `HTTPClient`

### Reason
This allows using custom clients.
We have custom http client with additional features, and we want to use it with retries. This module is awesome but now it's impossible to use it with out client.