### PR TITLE
Fix body nil checking in NewRequest

### DIFF
--- a/client.go
+++ b/client.go
@@ -34,6 +34,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -153,6 +154,10 @@ func (r *Request) WriteTo(w io.Writer) (int64, error) {
 func getBodyReaderAndContentLength(rawBody interface{}) (ReaderFunc, int64, error) {
 	var bodyReader ReaderFunc
 	var contentLength int64
+
+	if isNil(rawBody) {
+		return bodyReader, contentLength, nil
+	}
 
 	switch body := rawBody.(type) {
 	// If they gave us a function already, great! Use it.
@@ -771,4 +776,8 @@ func (c *Client) StandardClient() *http.Client {
 	return &http.Client{
 		Transport: &RoundTripper{Client: c},
 	}
+}
+
+func isNil(v interface{}) bool {
+	return v == nil || ((reflect.ValueOf(v).Kind() == reflect.Ptr || reflect.ValueOf(v).Kind() == reflect.Slice) && reflect.ValueOf(v).IsNil())
 }

--- a/client_test.go
+++ b/client_test.go
@@ -842,3 +842,21 @@ func TestClient_StandardClient(t *testing.T) {
 		t.Fatalf("expected %v, got %v", client, v)
 	}
 }
+
+func Test_NewRequest(t *testing.T) {
+	req, err := NewRequest("GET", "localhost:1234", nil)
+	if err != nil {
+		t.Fatalf("failed to create a request: %s", err)
+	}
+
+	var b []byte
+	b = nil
+	r, err := NewRequest("GET", "localhost:1234", b)
+	if err != nil {
+		t.Fatalf("failed to create a request: %s", err)
+	}
+
+	if req.body != nil || r.body != nil {
+		t.Fatalf("expected nil body for both requests, got:%v %v", req.body, r.body)
+	}
+}


### PR DESCRIPTION
NewRequest accepts interface{} as body argument
but doesn't check it on nil properly. It should
check that not only variable is nil, but also pointer
value is nil. Otherwise it constructs different
Request objects for the same parameters. Tests are
added.