### PR TITLE
client: support NewRequestWithContext

### DIFF
--- a/client.go
+++ b/client.go
@@ -255,20 +255,25 @@ func FromRequest(r *http.Request) (*Request, error) {
 	return &Request{bodyReader, r}, nil
 }
 
-// NewRequest creates a new wrapped request.
-func NewRequest(method, url string, rawBody interface{}) (*Request, error) {
+// NewRequestWithContext creates a new wrapped request.
+func NewRequestWithContext(ctx context.Context, method, url string, rawBody interface{}) (*Request, error) {
 	bodyReader, contentLength, err := getBodyReaderAndContentLength(rawBody)
 	if err != nil {
 		return nil, err
 	}
 
-	httpReq, err := http.NewRequest(method, url, nil)
+	httpReq, err := http.NewRequestWithContext(ctx, method, url, nil)
 	if err != nil {
 		return nil, err
 	}
 	httpReq.ContentLength = contentLength
 
 	return &Request{bodyReader, httpReq}, nil
+}
+
+// NewRequest creates a new wrapped request.
+func NewRequest(method, url string, rawBody interface{}) (*Request, error) {
+	return NewRequestWithContext(context.Background(), method, url, rawBody)
 }
 
 // Logger interface allows to use other loggers than

--- a/client_test.go
+++ b/client_test.go
@@ -167,18 +167,21 @@ func testClientDo(t *testing.T, body interface{}) {
 	// Send the request
 	var resp *http.Response
 	doneCh := make(chan struct{})
+	errCh := make(chan error)
 	go func() {
 		defer close(doneCh)
 		var err error
 		resp, err = client.Do(req)
 		if err != nil {
-			t.Fatalf("err: %v", err)
+			errCh <- err
 		}
 	}()
 
 	select {
 	case <-doneCh:
 		t.Fatalf("should retry on error")
+	case err := <-errCh:
+		t.Fatalf("err: %v", err)
 	case <-time.After(200 * time.Millisecond):
 		// Client should still be retrying due to connection failure.
 	}


### PR DESCRIPTION
See the docstring for http.NewRequestWithContext for a description of
the changes between http.NewRequest and http.NewRequestWithContext.

Fix a test that attempts to call Fatalf from a non-main goroutine,
which is not allowed in the upcoming Go 1.17 release.

Fixes #125.