### PR TITLE
WithContext should return a new Request

### DIFF
--- a/client.go
+++ b/client.go
@@ -94,8 +94,10 @@ type Request struct {
 // WithContext returns wrapped Request with a shallow copy of underlying *http.Request
 // with its context changed to ctx. The provided ctx must be non-nil.
 func (r *Request) WithContext(ctx context.Context) *Request {
-	r.Request = r.Request.WithContext(ctx)
-	return r
+	return &Request{
+		body:    r.body,
+		Request: r.Request.WithContext(ctx),
+	}
 }
 
 // BodyBytes allows accessing the request body. It is an analogue to

--- a/client_test.go
+++ b/client_test.go
@@ -468,18 +468,21 @@ func TestClient_RequestWithContext(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	ctx, cancel := context.WithCancel(req.Request.Context())
-	req = req.WithContext(ctx)
+	reqCtx := req.WithContext(ctx)
+	if reqCtx == req {
+		t.Fatal("WithContext must return a new Request object")
+	}
 
 	client := NewClient()
 
 	called := 0
 	client.CheckRetry = func(_ context.Context, resp *http.Response, err error) (bool, error) {
 		called++
-		return DefaultRetryPolicy(req.Request.Context(), resp, err)
+		return DefaultRetryPolicy(reqCtx.Request.Context(), resp, err)
 	}
 
 	cancel()
-	_, err = client.Do(req)
+	_, err = client.Do(reqCtx)
 
 	if called != 1 {
 		t.Fatalf("CheckRetry called %d times, expected 1", called)


### PR DESCRIPTION
The method should not mutate the original object. That is how the method from stdlib works.