### PR TITLE
NewRequestWithContext support

### DIFF
--- a/client.go
+++ b/client.go
@@ -257,12 +257,20 @@ func FromRequest(r *http.Request) (*Request, error) {
 
 // NewRequest creates a new wrapped request.
 func NewRequest(method, url string, rawBody interface{}) (*Request, error) {
+	return NewRequestWithContext(context.Background(), method, url, rawBody)
+}
+
+// NewRequestWithContext creates a new wrapped request with the provided context.
+//
+// The context controls the entire lifetime of a request and its response:
+// obtaining a connection, sending the request, and reading the response headers and body.
+func NewRequestWithContext(ctx context.Context, method, url string, rawBody interface{}) (*Request, error) {
 	bodyReader, contentLength, err := getBodyReaderAndContentLength(rawBody)
 	if err != nil {
 		return nil, err
 	}
 
-	httpReq, err := http.NewRequest(method, url, nil)
+	httpReq, err := http.NewRequestWithContext(ctx, method, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -456,6 +456,18 @@ func testClientResponseLogHook(t *testing.T, l interface{}, buf *bytes.Buffer) {
 	}
 }
 
+func TestClient_NewRequestWithContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r, err := NewRequestWithContext(ctx, http.MethodGet, "/abc", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if r.Context() != ctx {
+		t.Fatal("Context must be set")
+	}
+}
+
 func TestClient_RequestWithContext(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)


### PR DESCRIPTION
Fixes https://github.com/hashicorp/go-retryablehttp/issues/125.

Closes https://github.com/hashicorp/go-retryablehttp/pull/126.