### PR TITLE
Add support for RFC1123 Date/Time in Retry-After header.

### DIFF
--- a/client.go
+++ b/client.go
@@ -470,12 +470,14 @@ func baseRetryPolicy(resp *http.Response, err error) (bool, error) {
 // (HTTP Code 429) is found in the resp parameter. Hence it will return the number of
 // seconds the server states it may be ready to process more requests from this client.
 func DefaultBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
-	if resp != nil {
-		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
-			if s, ok := resp.Header["Retry-After"]; ok {
-				if sleep, err := strconv.ParseInt(s[0], 10, 64); err == nil {
-					return time.Second * time.Duration(sleep)
-				}
+	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+		if s, ok := resp.Header["Retry-After"]; ok {
+			if sleep, err := strconv.ParseInt(s[0], 10, 64); err == nil {
+				return time.Second * time.Duration(sleep)
+			}
+
+			if after, err := time.Parse(time.RFC1123, s[0]); err == nil {
+				return after.Sub(time.Now())
 			}
 		}
 	}


### PR DESCRIPTION
The Retry-After response HTTP header indicates how long the user agent should wait before making a follow-up request. It can be declared with a time duration or timestamp but go-retryablehttp supports only time duration.

Directives 
\<http-date\>
A date after which to retry. See the Date header for more details on the HTTP date format.

\<delay-seconds\>
A non-negative decimal integer indicating the seconds to delay after the response is received.