### PR TITLE
Allow custom rate limit header name to be specified

### DIFF
--- a/client.go
+++ b/client.go
@@ -380,7 +380,7 @@ type Client struct {
 	// For 429 Too Many Requests, sometimes the server returns
 	// a response header to indicate when the server is
 	// available to start processing request from client. This specifies
-	// the header name to loopkup in the response for 429s
+	// the header name to use from the response for 429s.
 	RateLimitHeaderName string
 }
 

--- a/client.go
+++ b/client.go
@@ -387,13 +387,13 @@ type Client struct {
 // NewClient creates a new Client with default settings.
 func NewClient() *Client {
 	return &Client{
-		HTTPClient:   cleanhttp.DefaultPooledClient(),
-		Logger:       defaultLogger,
-		RetryWaitMin: defaultRetryWaitMin,
-		RetryWaitMax: defaultRetryWaitMax,
-		RetryMax:     defaultRetryMax,
-		CheckRetry:   DefaultRetryPolicy,
-		Backoff:      DefaultBackoff,
+		HTTPClient:          cleanhttp.DefaultPooledClient(),
+		Logger:              defaultLogger,
+		RetryWaitMin:        defaultRetryWaitMin,
+		RetryWaitMax:        defaultRetryWaitMax,
+		RetryMax:            defaultRetryMax,
+		CheckRetry:          DefaultRetryPolicy,
+		Backoff:             DefaultBackoff,
 		RateLimitHeaderName: defaultRateLimitHeaderName,
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -554,7 +554,7 @@ func TestClient_DefaultBackoff(t *testing.T) {
 
 			client.CheckRetry = func(_ context.Context, resp *http.Response, err error) (bool, error) {
 				retryable, _ = DefaultRetryPolicy(context.Background(), resp, err)
-				retryAfter = DefaultBackoff(client.RetryWaitMin, client.RetryWaitMax, 1, resp)
+				retryAfter = DefaultBackoff(client.RetryWaitMin, client.RetryWaitMax, 1, resp, client.RateLimitHeaderName)
 				return false, nil
 			}
 
@@ -814,7 +814,7 @@ func TestBackoff(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		if v := DefaultBackoff(tc.min, tc.max, tc.i, nil); v != tc.expect {
+		if v := DefaultBackoff(tc.min, tc.max, tc.i, nil, defaultRateLimitHeaderName); v != tc.expect {
 			t.Fatalf("bad: %#v -> %s", tc, v)
 		}
 	}
@@ -824,7 +824,7 @@ func TestClient_BackoffCustom(t *testing.T) {
 	var retries int32
 
 	client := NewClient()
-	client.Backoff = func(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
+	client.Backoff = func(min, max time.Duration, attemptNum int, resp *http.Response, _ string) time.Duration {
 		atomic.AddInt32(&retries, 1)
 		return time.Millisecond * 1
 	}


### PR DESCRIPTION
Added support for specifying a custom header name in the client config when using `DefaultBackoff`. This approach makes it flexible to use `go-retryablehttp` client with servers that return header names different from `Retry-After` for rate limited responses and still take advantage of the default backoff logic implemented in this library.