### PR TITLE
Change URL from godoc to pkg.go.dev in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ standardClient := retryClient.StandardClient() // *http.Client
 ```
 
 For more usage and examples see the
-[godoc](http://godoc.org/github.com/hashicorp/go-retryablehttp).
+[pkg.go.dev](https://pkg.go.dev/github.com/hashicorp/go-retryablehttp).


### PR DESCRIPTION
Change URL from godoc to pkg.go.dev in README.md as godoc is not supported anymore.