### PR TITLE
Retry extra handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ The returned response object is an `*http.Response`, the same thing you would
 usually get from `net/http`. Had the request failed one or more times, the above
 call would block and retry with exponential backoff.
 
+## Retrying cases that fail after a seeming success
+
+It's possible for a request to succeed, but then for later processing to fail, and sometimes this requires retrying the full request. E.g. a GET that returns a lot of data may "succeed" but the connection may drop while reading all of the data.
+
+In such a case, you can use `DoWithResponseHandler` (or `GetWithResponseHandler`) rather than `Do` (or `Get`). A toy example (which will retry the full request and succeed on the second attempt) is shown below:
+
+```go
+c := retryablehttp.NewClient()
+handlerShouldRetry := false
+c.GetWithResponseHandler("/foo", func(*http.Response) bool {
+    handlerShouldRetry = !handlerShouldRetry
+    return handlerShouldRetry
+})
+```
+
 ## Getting a stdlib `*http.Client` with retries
 
 It's possible to convert a `*retryablehttp.Client` directly to a `*http.Client`.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ call would block and retry with exponential backoff.
 
 ## Retrying cases that fail after a seeming success
 
-It's possible for a request to succeed, but then for later processing to fail, and sometimes this requires retrying the full request. E.g. a GET that returns a lot of data may "succeed" but the connection may drop while reading all of the data.
+It's possible for a request to succeed in the sense that the expected response headers are received, but then to encounter network-level errors while reading the response body. In go-retryablehttp's most basic usage, this error would not be retryable, due to the out-of-band handling of the response body. In some cases it may be desirable to handle the response body as part of the retryable operation.
 
 In such a case, you can use `DoWithResponseHandler` (or `GetWithResponseHandler`) rather than `Do` (or `Get`). A toy example (which will retry the full request and succeed on the second attempt) is shown below:
 

--- a/client_test.go
+++ b/client_test.go
@@ -279,7 +279,7 @@ func TestClient_Do_WithResponseHandler(t *testing.T) {
 	var shouldSucceed bool
 	tests := []struct {
 		name           string
-		handler        ResponseHandlingFunc
+		handler        ResponseHandlerFunc
 		expectedChecks int // often 2x number of attempts since we check twice
 		err            string
 	}{

--- a/roundtripper_test.go
+++ b/roundtripper_test.go
@@ -107,12 +107,12 @@ func TestRoundTripper_TransportFailureErrorHandling(t *testing.T) {
 
 	expectedError := &url.Error{
 		Op:  "Get",
-		URL: "http://asdfsa.com/",
+		URL: "http://999.999.999.999:999/",
 		Err: &net.OpError{
 			Op:  "dial",
 			Net: "tcp",
 			Err: &net.DNSError{
-				Name:       "asdfsa.com",
+				Name:       "999.999.999.999",
 				Err:        "no such host",
 				IsNotFound: true,
 			},
@@ -121,7 +121,7 @@ func TestRoundTripper_TransportFailureErrorHandling(t *testing.T) {
 
 	// Get the standard client and execute the request.
 	client := retryClient.StandardClient()
-	_, err := client.Get("http://asdfsa.com/")
+	_, err := client.Get("http://999.999.999.999:999/")
 
 	// assert expectations
 	if !reflect.DeepEqual(expectedError, normalizeError(err)) {

--- a/roundtripper_test.go
+++ b/roundtripper_test.go
@@ -107,12 +107,12 @@ func TestRoundTripper_TransportFailureErrorHandling(t *testing.T) {
 
 	expectedError := &url.Error{
 		Op:  "Get",
-		URL: "http://this-url-does-not-exist-ed2fb.com/",
+		URL: "http://asdfsa.com/",
 		Err: &net.OpError{
 			Op:  "dial",
 			Net: "tcp",
 			Err: &net.DNSError{
-				Name:       "this-url-does-not-exist-ed2fb.com",
+				Name:       "asdfsa.com",
 				Err:        "no such host",
 				IsNotFound: true,
 			},
@@ -121,10 +121,10 @@ func TestRoundTripper_TransportFailureErrorHandling(t *testing.T) {
 
 	// Get the standard client and execute the request.
 	client := retryClient.StandardClient()
-	_, err := client.Get("http://this-url-does-not-exist-ed2fb.com/")
+	_, err := client.Get("http://asdfsa.com/")
 
 	// assert expectations
-	if !reflect.DeepEqual(normalizeError(err), expectedError) {
+	if !reflect.DeepEqual(expectedError, normalizeError(err)) {
 		t.Fatalf("expected %q, got %q", expectedError, err)
 	}
 }


### PR DESCRIPTION
Sometimes a request can "succeed" but fail later and in order to retry the later things, we have to retry the whole request. This PR adds an option to pass a "response handler" to deal with this situation.

The tests were failing (some genuinely, some because of new vet rules)

[Asana](https://app.asana.com/0/1200464981665630/1202082073961730/f)