### PR TITLE
add responseHandler option to GET/HEAD/POST helpers

### DIFF
--- a/client.go
+++ b/client.go
@@ -753,43 +753,46 @@ func (c *Client) drainBody(body io.ReadCloser) {
 
 // Get is a shortcut for doing a GET request without making a new client.
 func Get(url string) (*http.Response, error) {
-	return defaultClient.Get(url)
+	return defaultClient.Get(url, nil)
 }
 
 // Get is a convenience helper for doing simple GET requests.
-func (c *Client) Get(url string) (*http.Response, error) {
+func (c *Client) Get(url string, fn ResponseHandlerFunc) (*http.Response, error) {
 	req, err := NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
+	req.SetResponseHandler(fn)
 	return c.Do(req)
 }
 
 // Head is a shortcut for doing a HEAD request without making a new client.
 func Head(url string) (*http.Response, error) {
-	return defaultClient.Head(url)
+	return defaultClient.Head(url, nil)
 }
 
 // Head is a convenience method for doing simple HEAD requests.
-func (c *Client) Head(url string) (*http.Response, error) {
+func (c *Client) Head(url string, fn ResponseHandlerFunc) (*http.Response, error) {
 	req, err := NewRequest("HEAD", url, nil)
 	if err != nil {
 		return nil, err
 	}
+	req.SetResponseHandler(fn)
 	return c.Do(req)
 }
 
 // Post is a shortcut for doing a POST request without making a new client.
 func Post(url, bodyType string, body interface{}) (*http.Response, error) {
-	return defaultClient.Post(url, bodyType, body)
+	return defaultClient.Post(url, bodyType, body, nil)
 }
 
 // Post is a convenience method for doing simple POST requests.
-func (c *Client) Post(url, bodyType string, body interface{}) (*http.Response, error) {
+func (c *Client) Post(url, bodyType string, body interface{}, fn ResponseHandlerFunc) (*http.Response, error) {
 	req, err := NewRequest("POST", url, body)
 	if err != nil {
 		return nil, err
 	}
+	req.SetResponseHandler(fn)
 	req.Header.Set("Content-Type", bodyType)
 	return c.Do(req)
 }
@@ -803,7 +806,7 @@ func PostForm(url string, data url.Values) (*http.Response, error) {
 // PostForm is a convenience method for doing simple POST operations using
 // pre-filled url.Values form data.
 func (c *Client) PostForm(url string, data url.Values) (*http.Response, error) {
-	return c.Post(url, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
+	return c.Post(url, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()), nil)
 }
 
 // StandardClient returns a stdlib *http.Client with a custom Transport, which

--- a/client_test.go
+++ b/client_test.go
@@ -410,7 +410,7 @@ func TestClient_Get(t *testing.T) {
 	defer ts.Close()
 
 	// Make the request.
-	resp, err := NewClient().Get(ts.URL + "/foo/bar")
+	resp, err := NewClient().Get(ts.URL+"/foo/bar", nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -462,7 +462,7 @@ func testClientRequestLogHook(t *testing.T, logger interface{}) {
 	}
 
 	// Make the request.
-	resp, err := client.Get(ts.URL + testURIPath)
+	resp, err := client.Get(ts.URL+testURIPath, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -531,7 +531,7 @@ func testClientResponseLogHook(t *testing.T, l interface{}, buf *bytes.Buffer) {
 	}
 
 	// Perform the request. Exits when we finally get a 200.
-	resp, err := client.Get(ts.URL)
+	resp, err := client.Get(ts.URL, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -627,7 +627,7 @@ func TestClient_CheckRetry(t *testing.T) {
 	}
 
 	// CheckRetry should return our retryErr value and stop the retry loop.
-	_, err := client.Get(ts.URL)
+	_, err := client.Get(ts.URL, nil)
 
 	if called != 1 {
 		t.Fatalf("CheckRetry called %d times, expected 1", called)
@@ -658,7 +658,7 @@ func TestClient_DefaultBackoff(t *testing.T) {
 				return false, nil
 			}
 
-			_, err := client.Get(ts.URL)
+			_, err := client.Get(ts.URL, nil)
 			if err != nil {
 				t.Fatalf("expected no errors since retryable")
 			}
@@ -687,7 +687,7 @@ func TestClient_DefaultRetryPolicy_TLS(t *testing.T) {
 		return DefaultRetryPolicy(context.TODO(), resp, err)
 	}
 
-	_, err := client.Get(ts.URL)
+	_, err := client.Get(ts.URL, nil)
 	if err == nil {
 		t.Fatalf("expected x509 error, got nil")
 	}
@@ -709,7 +709,7 @@ func TestClient_DefaultRetryPolicy_redirects(t *testing.T) {
 		return DefaultRetryPolicy(context.TODO(), resp, err)
 	}
 
-	_, err := client.Get(ts.URL)
+	_, err := client.Get(ts.URL, nil)
 	if err == nil {
 		t.Fatalf("expected redirect error, got nil")
 	}
@@ -732,7 +732,7 @@ func TestClient_DefaultRetryPolicy_invalidscheme(t *testing.T) {
 	}
 
 	url := strings.Replace(ts.URL, "http", "ftp", 1)
-	_, err := client.Get(url)
+	_, err := client.Get(url, nil)
 	if err == nil {
 		t.Fatalf("expected scheme error, got nil")
 	}
@@ -756,7 +756,7 @@ func TestClient_CheckRetryStop(t *testing.T) {
 		return false, nil
 	}
 
-	_, err := client.Get(ts.URL)
+	_, err := client.Get(ts.URL, nil)
 
 	if called != 1 {
 		t.Fatalf("CheckRetry called %d times, expected 1", called)
@@ -781,7 +781,7 @@ func TestClient_Head(t *testing.T) {
 	defer ts.Close()
 
 	// Make the request.
-	resp, err := NewClient().Head(ts.URL + "/foo/bar")
+	resp, err := NewClient().Head(ts.URL+"/foo/bar", nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -819,7 +819,8 @@ func TestClient_Post(t *testing.T) {
 	resp, err := NewClient().Post(
 		ts.URL+"/foo/bar",
 		"application/json",
-		strings.NewReader(`{"hello":"world"}`))
+		strings.NewReader(`{"hello":"world"}`),
+		nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -939,7 +940,7 @@ func TestClient_BackoffCustom(t *testing.T) {
 	defer ts.Close()
 
 	// Make the request.
-	resp, err := client.Get(ts.URL + "/foo/bar")
+	resp, err := client.Get(ts.URL+"/foo/bar", nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}


### PR DESCRIPTION
I don't have a strong opinion about whether this is a good idea, or if the convenience methods should just be for the simplest cases. But seems convenient to allow using a response handler with these convenience methods, e.g. for this PR https://github.com/hashicorp/tfc-agent/pull/136

** Rollout **
Bump to v0.8.0 since it is a breaking change.

