### PR TITLE
Fixed a bug when Retry-After is 0, it should use min wait time.

### DIFF
--- a/client.go
+++ b/client.go
@@ -512,7 +512,11 @@ func DefaultBackoff(min, max time.Duration, attemptNum int, resp *http.Response)
 		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
 			if s, ok := resp.Header["Retry-After"]; ok {
 				if sleep, err := strconv.ParseInt(s[0], 10, 64); err == nil {
-					return time.Second * time.Duration(sleep)
+					if sleep > 0 {
+						return time.Second * time.Duration(sleep)
+					} else {
+						return min
+					}
 				}
 			}
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -640,37 +640,45 @@ func TestClient_CheckRetry(t *testing.T) {
 
 func TestClient_DefaultBackoff(t *testing.T) {
 	for _, code := range []int{http.StatusTooManyRequests, http.StatusServiceUnavailable} {
-		t.Run(fmt.Sprintf("http_%d", code), func(t *testing.T) {
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Retry-After", "2")
-				http.Error(w, fmt.Sprintf("test_%d_body", code), code)
-			}))
-			defer ts.Close()
+		for _, responseRetryAfter := range []string{"0", "2"} {
+			t.Run(fmt.Sprintf("http_%d", code), func(t *testing.T) {
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Retry-After", responseRetryAfter)
+					http.Error(w, fmt.Sprintf("test_%d_body", code), code)
+				}))
+				defer ts.Close()
 
-			client := NewClient()
+				client := NewClient()
 
-			var retryAfter time.Duration
-			retryable := false
+				var retryAfter time.Duration
+				retryable := false
 
-			client.CheckRetry = func(_ context.Context, resp *http.Response, err error) (bool, error) {
-				retryable, _ = DefaultRetryPolicy(context.Background(), resp, err)
-				retryAfter = DefaultBackoff(client.RetryWaitMin, client.RetryWaitMax, 1, resp)
-				return false, nil
-			}
+				client.CheckRetry = func(_ context.Context, resp *http.Response, err error) (bool, error) {
+					retryable, _ = DefaultRetryPolicy(context.Background(), resp, err)
+					retryAfter = DefaultBackoff(client.RetryWaitMin, client.RetryWaitMax, 1, resp)
+					return false, nil
+				}
 
-			_, err := client.Get(ts.URL)
-			if err != nil {
-				t.Fatalf("expected no errors since retryable")
-			}
+				_, err := client.Get(ts.URL)
+				if err != nil {
+					t.Fatalf("expected no errors since retryable")
+				}
 
-			if !retryable {
-				t.Fatal("Since the error is recoverable, the default policy shall return true")
-			}
+				if !retryable {
+					t.Fatal("Since the error is recoverable, the default policy shall return true")
+				}
 
-			if retryAfter != 2*time.Second {
-				t.Fatalf("The header Retry-After specified 2 seconds, and shall not be %d seconds", retryAfter/time.Second)
-			}
-		})
+				if responseRetryAfter == "0" {
+					if retryAfter != client.RetryWaitMin {
+						t.Fatalf("The header Retry-After specified %d seconds, and shall not be %d seconds", client.RetryWaitMin/time.Second, retryAfter/time.Second)
+					}
+				} else {
+					if retryAfter != 2*time.Second {
+						t.Fatalf("The header Retry-After specified 2 seconds, and shall not be %d seconds", retryAfter/time.Second)
+					}
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
In my test, I set rate limit `block_interval=5 rate=1`, then the first response had `Retry-After: 4` and the second response had `Retry-After: 0`, so that the second retry still failed.

When server responds `Retry-After: 0`, tests prove that immediate retry will fail also. Thus I think in that case MinWaitTime should be used.

The other approach I was thinking is to always return `Retry-After + 1`. When rate is 1, that should work better. As I my test case rate limit set to `block_interval=5 rate=1`, when hit rate limit, first 429 response will have `Retry-After: 4`, after 4 seconds, retry will hit 429 again with `Retry-After: 0`, then if retry immediately, if will hit 429 again. Thus if backoff is `Retry-After + 1`, that should work better.

But if `block_interval=1`, if we do `Retry-After + 1`, then retry interval will always be 1 second, which sounds not good, thus I chose the current approach I implemented in this PR.
