### PR TITLE
updated DefaultBackoff to return min of Retry-After or RetryWaitMax

### DIFF
--- a/client.go
+++ b/client.go
@@ -512,7 +512,11 @@ func DefaultBackoff(min, max time.Duration, attemptNum int, resp *http.Response)
 		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
 			if s, ok := resp.Header["Retry-After"]; ok {
 				if sleep, err := strconv.ParseInt(s[0], 10, 64); err == nil {
-					return time.Second * time.Duration(sleep)
+					sleepDuration := time.Second * time.Duration(sleep)
+					if sleepDuration < max {
+						return sleepDuration
+					}
+					return max
 				}
 			}
 		}


### PR DESCRIPTION
Resolves https://github.com/hashicorp/go-retryablehttp/issues/157