### PR TITLE
Update error log

### DIFF
--- a/client.go
+++ b/client.go
@@ -643,7 +643,7 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 			case LeveledLogger:
 				v.Error("request failed", "error", err, "method", req.Method, "url", req.URL)
 			case Logger:
-				v.Printf("[ERR] %s %s request failed: %v", req.Method, req.URL, err)
+				v.Printf("[ERROR] %s %s request failed: %v", req.Method, req.URL, err)
 			}
 		} else {
 			// Call this here to maintain the behavior of logging all requests,
@@ -752,7 +752,7 @@ func (c *Client) drainBody(body io.ReadCloser) {
 			case LeveledLogger:
 				v.Error("error reading response body", "error", err)
 			case Logger:
-				v.Printf("[ERR] error reading response body: %v", err)
+				v.Printf("[ERROR] error reading response body: %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
Change `ERR` to `ERROR` for consistency in our libraries.

To Do:
* Find out context for the different loggers. When running a `terraform apply` I saw the following log output from this library:

```
2022-12-23T18:19:35.431-0700 [INFO]  CLI command args: []string{"apply"}
2022/12/23 18:19:35 [DEBUG] GET https://app.terraform.io/.well-known/terraform.json
```

The `DEBUG` prints even if `TF_LOG` is set to `info` (which I did in this case). Also would be nice to have consistent date/time stamps.