### PR TITLE
Convert hashicorp/go-retryablehttp to GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,14 @@
+# If the repository is public, be sure to change to GitHub hosted runners
+name: Lint GitHub Actions Workflows
+on:
+  push:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: "Check workflow files"
+        uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:latest

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,14 +1,19 @@
-# If the repository is public, be sure to change to GitHub hosted runners
-name: Lint GitHub Actions Workflows
+name: actionlint
+
 on:
   push:
-  pull_request:
+    paths:
+      - .github/**
+
 permissions:
   contents: read
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - name: "Check workflow files"
+      - name: "Check GitHub workflow files"
         uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:latest
+        with:
+          args: -color -ignore SC2086

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -12,8 +12,8 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - name: "Check GitHub workflow files"
         uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:latest
         with:
-          args: -color -ignore SC2086
+          args: -color

--- a/.github/workflows/go-retryablehttp.yml
+++ b/.github/workflows/go-retryablehttp.yml
@@ -13,9 +13,9 @@ jobs:
         go-version:
         - 1.14.2
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
     - run: mkdir -p $TEST_RESULTS/go-retryablyhttp
-    - uses: actions/setup-go@v4.0.0
+    - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
         cache: true
     - run: go mod download
@@ -31,9 +31,9 @@ jobs:
       run: |-
         PACKAGE_NAMES=$(go list ./...)
         gotestsum --format=short-verbose --junitfile $TEST_RESULTS/go-retryablyhttp/gotestsum-report.xml -- $PACKAGE_NAMES
-    - uses: actions/upload-artifact@v3.1.1
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         path: "/tmp/test-results"
-    - uses: actions/upload-artifact@v3.1.1
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         path: "/tmp/test-results"

--- a/.github/workflows/go-retryablehttp.yml
+++ b/.github/workflows/go-retryablehttp.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run unit tests
         run: |-
           PACKAGE_NAMES=$(go list ./...)
-          gotestsum --format=short-verbose --junitfile $TEST_RESULTS/go-retryablyhttp/gotestsum-report.xml -- $PACKAGE_NAMES
+          gotestsum --junitfile "${TEST_RESULTS}"/go-retryablyhttp/gotestsum-report.xml -- $PACKAGE_NAMES
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           path: "/tmp/test-results"

--- a/.github/workflows/go-retryablehttp.yml
+++ b/.github/workflows/go-retryablehttp.yml
@@ -17,8 +17,15 @@ jobs:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - run: mkdir -p $TEST_RESULTS/go-retryablyhttp
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+      - name: Setup cache for go modules
+        uses: actions/cache@v3
         with:
-          cache: true
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - run: go mod download
       - name: Run go format
         run: |-
@@ -28,7 +35,9 @@ jobs:
             echo "$files"
             exit 1
           fi
-      - name: Run tests with gotestsum
+      - name: Install gotestsum
+        run: go get gotest.tools/gotestsum
+      - name: Run unit tests
         run: |-
           PACKAGE_NAMES=$(go list ./...)
           gotestsum --format=short-verbose --junitfile $TEST_RESULTS/go-retryablyhttp/gotestsum-report.xml -- $PACKAGE_NAMES

--- a/.github/workflows/go-retryablehttp.yml
+++ b/.github/workflows/go-retryablehttp.yml
@@ -9,23 +9,19 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_RESULTS: "/tmp/test-results"
-    strategy:
-      matrix:
-        go-version:
-          - 1.14.2
     steps:
+      - name: Setup go
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          go-version: 1.14.2
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - run: mkdir -p $TEST_RESULTS/go-retryablyhttp
-      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-      - name: Setup cache for go modules
-        uses: actions/cache@v3
+      - name: restore_cache
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          key: go-mod-v1-{{ checksum "go.sum" }}
+          restore-keys: go-mod-v1-{{ checksum "go.sum" }}
+          path: "/go/pkg/mod"
       - run: go mod download
       - name: Run go format
         run: |-

--- a/.github/workflows/go-retryablehttp.yml
+++ b/.github/workflows/go-retryablehttp.yml
@@ -2,7 +2,7 @@ name: hashicorp/go-retryablehttp/go-retryablehttp
 on:
   push:
     branches:
-    - master
+      - master
 jobs:
   run-tests:
     runs-on: ubuntu-latest
@@ -11,29 +11,31 @@ jobs:
     strategy:
       matrix:
         go-version:
-        - 1.14.2
+          - 1.14.2
     steps:
-    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
-    - run: mkdir -p $TEST_RESULTS/go-retryablyhttp
-    - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-      with:
-        cache: true
-    - run: go mod download
-    - name: Run go format
-      run: |-
-        files=$(go fmt ./...)
-        if [ -n "$files" ]; then
-          echo "The following file(s) do not conform to go fmt:"
-          echo "$files"
-          exit 1
-        fi
-    - name: Run tests with gotestsum
-      run: |-
-        PACKAGE_NAMES=$(go list ./...)
-        gotestsum --format=short-verbose --junitfile $TEST_RESULTS/go-retryablyhttp/gotestsum-report.xml -- $PACKAGE_NAMES
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-      with:
-        path: "/tmp/test-results"
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-      with:
-        path: "/tmp/test-results"
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      - run: mkdir -p $TEST_RESULTS/go-retryablyhttp
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          cache: true
+      - run: go mod download
+      - name: Run go format
+        run: |-
+          files=$(go fmt ./...)
+          if [ -n "$files" ]; then
+            echo "The following file(s) do not conform to go fmt:"
+            echo "$files"
+            exit 1
+          fi
+      - name: Run tests with gotestsum
+        run: |-
+          PACKAGE_NAMES=$(go list ./...)
+          gotestsum --format=short-verbose --junitfile $TEST_RESULTS/go-retryablyhttp/gotestsum-report.xml -- $PACKAGE_NAMES
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          path: "/tmp/test-results"
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          path: "/tmp/test-results"
+permissions:
+  contents: read

--- a/.github/workflows/go-retryablehttp.yml
+++ b/.github/workflows/go-retryablehttp.yml
@@ -1,8 +1,9 @@
-name: hashicorp/go-retryablehttp/go-retryablehttp
+name: Build
 on:
   push:
     branches:
       - master
+      - convert-hashicorp-go-retryablehttp-to-actions-20230403-212814
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-retryablehttp.yml
+++ b/.github/workflows/go-retryablehttp.yml
@@ -1,9 +1,6 @@
 name: Build
 on:
   push:
-    branches:
-      - master
-      - convert-hashicorp-go-retryablehttp-to-actions-20230403-212814
 jobs:
   run-tests:
     runs-on: ubuntu-latest
@@ -15,7 +12,7 @@ jobs:
         with:
           go-version: 1.14.2
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
-      - run: mkdir -p $TEST_RESULTS/go-retryablyhttp
+      - run: mkdir -p "$TEST_RESULTS"/go-retryablyhttp
       - name: restore_cache
         uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
         with:
@@ -36,6 +33,7 @@ jobs:
       - name: Run unit tests
         run: |-
           PACKAGE_NAMES=$(go list ./...)
+          # shellcheck disable=SC2086 # can't quote package list
           gotestsum --junitfile "${TEST_RESULTS}"/go-retryablyhttp/gotestsum-report.xml -- $PACKAGE_NAMES
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/go-retryablehttp.yml
+++ b/.github/workflows/go-retryablehttp.yml
@@ -1,0 +1,39 @@
+name: hashicorp/go-retryablehttp/go-retryablehttp
+on:
+  push:
+    branches:
+    - master
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    env:
+      TEST_RESULTS: "/tmp/test-results"
+    strategy:
+      matrix:
+        go-version:
+        - 1.14.2
+    steps:
+    - uses: actions/checkout@v3.5.0
+    - run: mkdir -p $TEST_RESULTS/go-retryablyhttp
+    - uses: actions/setup-go@v4.0.0
+      with:
+        cache: true
+    - run: go mod download
+    - name: Run go format
+      run: |-
+        files=$(go fmt ./...)
+        if [ -n "$files" ]; then
+          echo "The following file(s) do not conform to go fmt:"
+          echo "$files"
+          exit 1
+        fi
+    - name: Run tests with gotestsum
+      run: |-
+        PACKAGE_NAMES=$(go list ./...)
+        gotestsum --format=short-verbose --junitfile $TEST_RESULTS/go-retryablyhttp/gotestsum-report.xml -- $PACKAGE_NAMES
+    - uses: actions/upload-artifact@v3.1.1
+      with:
+        path: "/tmp/test-results"
+    - uses: actions/upload-artifact@v3.1.1
+      with:
+        path: "/tmp/test-results"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+# Submit a helpdesk ticket to add any team other than yours referenced in the CODEOWNERS file -- they must be added to collaborators and teams in the repository settings with maintainer privileges. Remove this file as soon as you have completed this

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-# Submit a helpdesk ticket to add any team other than yours referenced in the CODEOWNERS file -- they must be added to collaborators and teams in the repository settings with maintainer privileges. Remove this file as soon as you have completed this
+* @hashicorp/release-engineering


### PR DESCRIPTION
Pipeline migrated from [CircleCI](https://app.circleci.com/pipelines/github/hashicorp/go-retryablehttp) :tada:

Passing tests: https://github.com/hashicorp/go-retryablehttp/actions/runs/4601722195

PR that removes CCI config: #185

Would also be interested in converting this repo to use `main` instead of `master` -- I can do that after I merge in this PR. 