### PR TITLE
Bugfix: fix mishandling of POST/PUT requests with empty body, causing net/http to send request without a `Content-Length` header

### DIFF
--- a/client.go
+++ b/client.go
@@ -260,10 +260,17 @@ func getBodyReaderAndContentLength(rawBody interface{}) (ReaderFunc, int64, erro
 		if err != nil {
 			return nil, 0, err
 		}
-		bodyReader = func() (io.Reader, error) {
-			return bytes.NewReader(buf), nil
+		if len(buf) == 0 {
+			bodyReader = func() (io.Reader, error) {
+				return http.NoBody, nil
+			}
+			contentLength = 0
+		} else {
+			bodyReader = func() (io.Reader, error) {
+				return bytes.NewReader(buf), nil
+			}
+			contentLength = int64(len(buf))
 		}
-		contentLength = int64(len(buf))
 
 	// No body provided, nothing to do
 	case nil:


### PR DESCRIPTION
This PR addresses a mishandling of POST and PUT requests having an empty body.

In a few places within `net/http`, in order to determine whether the reuqest has a body or not, the `http.Request.Body` which is an `io.ReadCloser`, does not have its `Read()` method called but is instead simply compared to `nil` or the `http.NoBody` value - so even if its `Read()` method returns `0, io.EOF` it's still considered to represent a nonempty request body.

```go
// NoBody is an io.ReadCloser with no bytes. Read always returns EOF
// and Close always returns nil. It can be used in an outgoing client
// request to explicitly signal that a request has zero bytes.
// An alternative, however, is to simply set Request.Body to nil.
var NoBody = noBody{}

type noBody struct{}

func (noBody) Read([]byte) (int, error)         { return 0, io.EOF }
func (noBody) Close() error                     { return nil }
func (noBody) WriteTo(io.Writer) (int64, error) { return 0, nil }
```

(Note this docstring also suggests that you should set `Request.Body` to `nil` or `http.NoBody`)

For HTTP/1.1,  even when the request body is an `io.ReadCloser` with a zero length buffer, the resulting request on the wire then contains neither a `Content-Length` nor a `Transfer-Encoding` header and is therefore invalid (incurring a 411 response from a compliant server).

For HTTP/2.0, the [`http.http2actualContentLength()`](https://github.com/golang/go/blob/fe10464358057778732e9c958683039beb64e61a/src/net/http/h2_bundle.go#L8210-L8221) function, if it isn't specifically `http.NoBody`, the `Content-Length` is incorrectly discarded instead of being set to zero, which has the same effect.