### PR TITLE
Avoid reading all from bytes.Reader when get request body

### DIFF
--- a/client.go
+++ b/client.go
@@ -234,14 +234,12 @@ func getBodyReaderAndContentLength(rawBody interface{}) (ReaderFunc, int64, erro
 	// deal with it seeking so want it to match here instead of the
 	// io.ReadSeeker case.
 	case *bytes.Reader:
-		buf, err := ioutil.ReadAll(body)
-		if err != nil {
-			return nil, 0, err
-		}
+		snapshot := *body
 		bodyReader = func() (io.Reader, error) {
-			return bytes.NewReader(buf), nil
+			r := snapshot
+			return &r, nil
 		}
-		contentLength = int64(len(buf))
+		contentLength = int64(body.Len())
 
 	// Compat case
 	case io.ReadSeeker:


### PR DESCRIPTION
Avoid reading all bytes from `bytes.Reader` to save memory.

See also `Request.NewRequestWithContext()` in `net/http`.

Ref: https://github.com/golang/go/blob/e71b61180aa19a60c23b3b7e3f6586726ebe4fd1/src/net/http/request.go#L881-L887