### PR TITLE
fix: using errors.As to check x509 error

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,6 +28,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -483,7 +484,7 @@ func baseRetryPolicy(resp *http.Response, err error) (bool, error) {
 			if notTrustedErrorRe.MatchString(v.Error()) {
 				return false, v
 			}
-			if _, ok := v.Err.(x509.UnknownAuthorityError); ok {
+			if errors.As(v.Err, &x509.UnknownAuthorityError{}) {
 				return false, v
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hashicorp/go-retryablehttp
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-hclog v0.9.2
+	github.com/stretchr/testify v1.2.2
 )
 
 go 1.13


### PR DESCRIPTION
using errors.As to check error is x509 or not, fix #201 

errors.As is imported golang 1.13