### PR TITLE
client.baseRetryPolicy check if response is nil before accessing attributes 

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,6 +28,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -490,6 +491,11 @@ func baseRetryPolicy(resp *http.Response, err error) (bool, error) {
 
 		// The error is likely recoverable so retry.
 		return true, nil
+	}
+
+	// check if is nil to make below attributes access safe
+	if resp == nil {
+		return false, errors.New("response is nil")
 	}
 
 	// 429 Too Many Requests is recoverable. Sometimes the server puts

--- a/client_test.go
+++ b/client_test.go
@@ -978,3 +978,16 @@ func TestClient_StandardClient(t *testing.T) {
 		t.Fatalf("expected %v, got %v", client, v)
 	}
 }
+
+func TestClient_baseRetryPolicy(t *testing.T) {
+	t.Parallel()
+	var response *http.Response = nil
+
+	ok, err := baseRetryPolicy(response, nil)
+	if ok {
+		t.Fatalf("expected %v, got %v", false, ok)
+	}
+	if err == nil {
+		t.Fatalf("should error")
+	}
+}


### PR DESCRIPTION
`baseRetryPolicy`
if accessable from publis `DefaultRetryPolicy` and `ErrorPropagatedRetryPolicy` and it is called without any checks.
There can be case when use call this function with passing nil response inside and catch `panic`.
With this changes they get error with explanation.