### PR TITLE
Sets request's GetBody field on create wrapper

### DIFF
--- a/.github/workflows/go-retryablehttp.yml
+++ b/.github/workflows/go-retryablehttp.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: 1.14.2
+          go-version: 1.18
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - run: mkdir -p "$TEST_RESULTS"/go-retryablyhttp
       - name: restore_cache
@@ -20,6 +20,7 @@ jobs:
           restore-keys: go-mod-v1-{{ checksum "go.sum" }}
           path: "/go/pkg/mod"
       - run: go mod download
+      - run: go mod tidy
       - name: Run go format
         run: |-
           files=$(go fmt ./...)
@@ -29,7 +30,7 @@ jobs:
             exit 1
           fi
       - name: Install gotestsum
-        run: go get gotest.tools/gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Run unit tests
         run: |-
           PACKAGE_NAMES=$(go list ./...)

--- a/client.go
+++ b/client.go
@@ -160,6 +160,20 @@ func (r *Request) SetBody(rawBody interface{}) error {
 	}
 	r.body = bodyReader
 	r.ContentLength = contentLength
+	if bodyReader != nil {
+		r.GetBody = func() (io.ReadCloser, error) {
+			body, err := bodyReader()
+			if err != nil {
+				return nil, err
+			}
+			if rc, ok := body.(io.ReadCloser); ok {
+				return rc, nil
+			}
+			return io.NopCloser(body), nil
+		}
+	} else {
+		r.GetBody = func() (io.ReadCloser, error) { return http.NoBody, nil }
+	}
 	return nil
 }
 
@@ -302,18 +316,19 @@ func NewRequest(method, url string, rawBody interface{}) (*Request, error) {
 // The context controls the entire lifetime of a request and its response:
 // obtaining a connection, sending the request, and reading the response headers and body.
 func NewRequestWithContext(ctx context.Context, method, url string, rawBody interface{}) (*Request, error) {
-	bodyReader, contentLength, err := getBodyReaderAndContentLength(rawBody)
-	if err != nil {
-		return nil, err
-	}
-
 	httpReq, err := http.NewRequestWithContext(ctx, method, url, nil)
 	if err != nil {
 		return nil, err
 	}
-	httpReq.ContentLength = contentLength
 
-	return &Request{body: bodyReader, Request: httpReq}, nil
+	req := &Request{
+		Request: httpReq,
+	}
+	if err := req.SetBody(rawBody); err != nil {
+		return nil, err
+	}
+
+	return req, nil
 }
 
 // Logger interface allows to use other loggers than


### PR DESCRIPTION
Closes #121 

This commit addresses two key issues:
- Upon receiving a temporary redirect, net/http will only preserve the request's body if GetBody() is [defined](https://pkg.go.dev/net/http#Client.Do) (third to last sentence in the paragraph).
- Upon receiving a GOAWAY frame, the client will create a new connection. We define GetBody() in order to reuse the body sent in the last stream on the now terminated connection.

Not entirely sure why the fix was never merged, but here we are :) Credits to @rgb-24bit