### PR TITLE
Re-sign request on retry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mgwoj/go-retryablehttp
+module github.com/hashicorp/go-retryablehttp
 
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.2


### PR DESCRIPTION
In our case we need to re-sign request before initiating retry operation. To achieve that we have added a new handler `PrepareRetry` which can be used for this purpose, however the signature and the name is as generic as possible.