### PR TITLE
Allow errors from CheckRetry to be logged

### DIFF
--- a/client.go
+++ b/client.go
@@ -663,6 +663,9 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 		if respErr != nil {
 			err = respErr
 		}
+		if err == nil && checkErr != nil {
+			err = checkErr
+		}
 		if err != nil {
 			switch v := logger.(type) {
 			case LeveledLogger:


### PR DESCRIPTION
With HTTP requests, there are requests which "succeed" in terms of the HTTP standard, but are failures for a "normal" client. For example, 503 status returns.

With the DefaultCheckRetry, 503 errors *are* set to be retried, but since the request itself completed without error, this "error" isn't communicated to the user at all. So to the user, it can seem like code is hanging, when in reality, it's doing the "correct" backoffs and retries.

This change therefore will additionally print the error logs if `checkErr` is non-nil