### PR TITLE
Fix preparing of POST/PUT requests not taking into account request body

### DIFF
--- a/client.go
+++ b/client.go
@@ -687,6 +687,14 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 			}
 		}
 
+		// First attempt was already signed
+		if attempt > 1 && c.PrepareRetry != nil {
+			if err := c.PrepareRetry(req.Request); err != nil {
+				prepareErr = err
+				break
+			}
+		}
+
 		if c.RequestLogHook != nil {
 			switch v := logger.(type) {
 			case LeveledLogger:
@@ -778,12 +786,6 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 		httpreq := *req.Request
 		req.Request = &httpreq
 
-		if c.PrepareRetry != nil {
-			if err := c.PrepareRetry(req.Request); err != nil {
-				prepareErr = err
-				break
-			}
-		}
 	}
 
 	// this is the closest we have to success criteria


### PR DESCRIPTION
Hi, in our case we are using a POST body to generate an auth header. The problem is that for the retried requests, it is not taken into account. With this change the request is prepared before sending it and enabling us to construct correct payload. I also added a couple of test cases.

Let me know what you think.

Thanks, 
Dawid