### PR TITLE
Honour "Retry-After" header value only if its less than or equal to RetryWaitMax in default retry strategy

### DIFF
--- a/client.go
+++ b/client.go
@@ -552,7 +552,7 @@ func DefaultBackoff(min, max time.Duration, attemptNum int, resp *http.Response)
 	if resp != nil {
 		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
 			if sleep, ok := parseRetryAfterHeader(resp.Header["Retry-After"]); ok {
-				return sleep
+				if sleep <= max return sleep
 			}
 		}
 	}


### PR DESCRIPTION
https://github.com/hashicorp/go-retryablehttp/issues/247

Currently the DefaultBackoff in function has a logical flaw when handling the Retry-After header. If the server provides an unreasonably high value in the Retry-After header, the function respects it without enforcing the RetryWaitMax limit set for the httpClient. This can lead to indefinite wait times or blocking behaviour.

This change will make sure that "Retry-After" header value is honoured only if its less than or equal to RetryWaitMax in default retry strategy.

