### PR TITLE
feat: RetryAttempt in PrepareRetry hook

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -376,9 +376,9 @@ func TestClient_Do_WithPrepareRetry(t *testing.T) {
 	}
 
 	var prepareChecks int
-	client.PrepareRetry = func(req *http.Request) error {
+	client.PrepareRetry = func(req *http.Request, retryAttempt int) error {
 		prepareChecks++
-		req.Header.Set("foo", strconv.Itoa(prepareChecks))
+		req.Header.Set("foo", strconv.Itoa(retryAttempt))
 		return nil
 	}
 


### PR DESCRIPTION
Adding the retryAttempt counter, which refers to the current retry attempt to enable the server and client to make an informed decision to process the requests. For example,
- The client can hit a fallback host (server) based on the retry attempt.
- The client can send the retry count in the header, and the server can process the request in any special way.