### PR TITLE
Remove team-ip-compliance from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # Default owner
-* @hashicorp/team-ip-compliance @hashicorp/go-retryablehttp-maintainers
+* @hashicorp/go-retryablehttp-maintainers
 
 # Add override rules below. Each line is a file/folder pattern followed by one or more owners.
 # Being an owner means those groups or individuals will be added as reviewers to PRs affecting


### PR DESCRIPTION
Based on team discussion, Katie and Steve will take ownership of the repository. The go-retryablehttp-maintainers group will handle code reviews going forward.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

This PR removes `@hashicorp/team-ip-compliance` from the CODEOWNERS file based on team discussion. Katie and Steve have confirmed they will take ownership of the go-retryablehttp repository, and the `@hashicorp/go-retryablehttp-maintainers` group will handle code reviews going forward without requiring review from the IP compliance team.

## Related Issue

This change is based on internal team discussion regarding repository ownership transition. The IP and Compliance team reached out to confirm ownership, and Katie confirmed they would take responsibility for the repository maintenance.

## How Has This Been Tested?

- Verified that the CODEOWNERS file syntax is correct
- Confirmed that only `@hashicorp/go-retryablehttp-maintainers` remains as the default owner
- No functional testing required as this is a configuration change that only affects GitHub's automatic reviewer assignment for future PRs