### PR TITLE
fix misleading log info

### DIFF
--- a/client.go
+++ b/client.go
@@ -776,7 +776,7 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 			}
 			switch v := logger.(type) {
 			case LeveledLogger:
-				v.Debug("retrying request", "request", desc, "timeout", wait, "remaining", remain)
+				v.Debug("retrying request", "request", desc, "wait", wait, "remaining", remain)
 			case Logger:
 				v.Printf("[DEBUG] %s: retrying in %s (%d left)", desc, wait, remain)
 			}


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

This PR updates the log field name from `timeout` to `wait` for wait information to improve clarity and reduce confusion.
