### PR TITLE
fix: cap Retry-After sleep to RetryWaitMax in DefaultBackoff

### DIFF
--- a/client.go
+++ b/client.go
@@ -552,6 +552,9 @@ func DefaultBackoff(min, max time.Duration, attemptNum int, resp *http.Response)
 	if resp != nil {
 		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
 			if sleep, ok := parseRetryAfterHeader(resp.Header["Retry-After"]); ok {
+				if sleep > max {
+					return max
+				}
 				return sleep
 			}
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -896,6 +896,51 @@ func TestClient_DefaultBackoff(t *testing.T) {
 	}
 }
 
+// TestClient_DefaultBackoff_RetryAfterExceedsMax verifies that DefaultBackoff
+// caps the sleep duration from a Retry-After header at RetryWaitMax so that
+// a server cannot force an arbitrarily long wait.
+func TestClient_DefaultBackoff_RetryAfterExceedsMax(t *testing.T) {
+	testStaticTime(t)
+	const retryWaitMax = 10 * time.Second
+
+	tests := []struct {
+		name        string
+		code        int
+		retryHeader string
+	}{
+		{"http_429_seconds_exceeds_max", http.StatusTooManyRequests, "3600"},
+		{"http_503_seconds_exceeds_max", http.StatusServiceUnavailable, "3600"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Retry-After", test.retryHeader)
+				http.Error(w, fmt.Sprintf("test_%d_body", test.code), test.code)
+			}))
+			defer ts.Close()
+
+			client := NewClient()
+			client.RetryWaitMax = retryWaitMax
+
+			var got time.Duration
+			client.CheckRetry = func(_ context.Context, resp *http.Response, err error) (bool, error) {
+				got = DefaultBackoff(client.RetryWaitMin, client.RetryWaitMax, 1, resp)
+				return false, nil
+			}
+
+			_, err := client.Get(ts.URL)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			if got != retryWaitMax {
+				t.Fatalf("Retry-After of 3600s should be capped to RetryWaitMax=%s, got %s", retryWaitMax, got)
+			}
+		})
+	}
+}
+
 func TestClient_DefaultRetryPolicy_TLS(t *testing.T) {
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)


### PR DESCRIPTION
## Problem

When a server responds with a `Retry-After` header (e.g. `Retry-After: 3600`), `DefaultBackoff` unconditionally sleeps for that duration — completely ignoring the client's configured `RetryWaitMax`. This means a misbehaving or malicious server can force a client to sleep for an arbitrarily long time, bypassing the user's intent.

Fixes #247.

## Root cause

```go
// before — no cap applied
if sleep, ok := parseRetryAfterHeader(resp.Header["Retry-After"]); ok {
    return sleep   // could be hours
}
```

## Fix

Cap the `Retry-After` sleep at `max` (which is `RetryWaitMax`):

```go
if sleep, ok := parseRetryAfterHeader(resp.Header["Retry-After"]); ok {
    if sleep > max {
        return max
    }
    return sleep
}
```

This is consistent with how the exponential backoff path already respects `RetryWaitMax`.

## Tests

Added `TestClient_DefaultBackoff_RetryAfterExceedsMax` covering:
- HTTP 429 with `Retry-After: 3600` → capped to `RetryWaitMax` (10s)
- HTTP 503 with `Retry-After: 3600` → capped to `RetryWaitMax` (10s)

All existing tests pass.