### PR TITLE
Don't start backoff timer if it would exceed context deadline

### DIFF
--- a/client.go
+++ b/client.go
@@ -781,6 +781,10 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 				v.Printf("[DEBUG] %s: retrying in %s (%d left)", desc, wait, remain)
 			}
 		}
+		if deadline, ok := req.Context().Deadline(); ok && time.Now().Add(wait).After(deadline) {
+			c.HTTPClient.CloseIdleConnections()
+			return nil, req.Context().Err()
+		}
 		timer := time.NewTimer(wait)
 		select {
 		case <-req.Context().Done():


### PR DESCRIPTION
If the calculated backoff wait would push past the context deadline, we're just going to block until the deadline fires and get `context.DeadlineExceeded` anyway. This change checks for that upfront and returns immediately instead of sleeping unnecessarily.

The fix is a single deadline check before `time.NewTimer`:

```go
if deadline, ok := req.Context().Deadline(); ok && time.Now().Add(wait).After(deadline) {
    c.HTTPClient.CloseIdleConnections()
    return nil, req.Context().Err()
}
```

This makes callers with tight deadlines get the error back faster, without the full backoff sleep eating into their remaining budget.

Existing tests pass (`go test ./...`).

Fixes #272