### PR TITLE
Fix tests for current Go and hermetic transport failures

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -676,7 +676,7 @@ func testClientResponseLogHook(t *testing.T, l interface{}, buf *bytes.Buffer) {
 			successLog := "test_log_pass"
 			// Log something when we get a 200
 			if logger != nil {
-				logger.Printf(successLog)
+				logger.Printf("%s", successLog)
 			} else {
 				buf.WriteString(successLog)
 			}
@@ -688,7 +688,7 @@ func testClientResponseLogHook(t *testing.T, l interface{}, buf *bytes.Buffer) {
 			}
 			failLog := string(body)
 			if logger != nil {
-				logger.Printf(failLog)
+				logger.Printf("%s", failLog)
 			} else {
 				buf.WriteString(failLog)
 			}

--- a/roundtripper_test.go
+++ b/roundtripper_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"sync/atomic"
 	"testing"
 )
@@ -110,27 +109,26 @@ func TestRoundTripper_TransportFailureErrorHandling(t *testing.T) {
 
 	retryClient.ErrorHandler = PassthroughErrorHandler
 
-	expectedError := &url.Error{
-		Op:  "Get",
-		URL: "http://999.999.999.999:999/",
-		Err: &net.OpError{
-			Op:  "dial",
-			Net: "tcp",
-			Err: &net.DNSError{
-				Name:       "999.999.999.999",
-				Err:        "no such host",
-				IsNotFound: true,
-			},
-		},
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetURL := "http://" + ln.Addr().String() + "/"
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
 	}
 
 	// Get the standard client and execute the request.
 	client := retryClient.StandardClient()
-	_, err := client.Get("http://999.999.999.999:999/")
+	_, err = client.Get(targetURL)
 
 	// assert expectations
-	if !reflect.DeepEqual(expectedError, normalizeError(err)) {
-		t.Fatalf("expected %q, got %q", expectedError, err)
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) {
+		t.Fatalf("expected url.Error, got %T: %v", err, err)
+	}
+	if urlErr.Op != "Get" || urlErr.URL != targetURL {
+		t.Fatalf("expected Get %q error, got %q %q", targetURL, urlErr.Op, urlErr.URL)
 	}
 }
 


### PR DESCRIPTION
## Description

- Use explicit format strings where current Go vet rejects non-constant logger format strings.
- Make the transport failure test hermetic instead of relying on a dial failure path that can vary by environment.

## Related Issue

N/A

## How Has This Been Tested?

- `go test ./...`