### PR TITLE
fix: preserve final response in PassthroughErrorHandler

### DIFF
--- a/client.go
+++ b/client.go
@@ -656,9 +656,13 @@ func RateLimitLinearJitterBackoff(min, max time.Duration, attemptNum int, resp *
 }
 
 // PassthroughErrorHandler is an ErrorHandler that directly passes through the
-// values from the net/http library for the final request. The body is not
-// closed.
+// final response when one exists. This keeps standard-library callers such as
+// http.Client from discarding the response because of a non-nil error. The
+// body is not closed.
 func PassthroughErrorHandler(resp *http.Response, err error, _ int) (*http.Response, error) {
+	if resp != nil {
+		return resp, nil
+	}
 	return resp, err
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -626,6 +626,21 @@ func testClientRequestLogHook(t *testing.T, logger interface{}) {
 	}
 }
 
+func TestPassthroughErrorHandler_ReturnsResponseWithoutError(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(strings.NewReader("retry me")),
+	}
+
+	gotResp, gotErr := PassthroughErrorHandler(resp, errors.New("retry stopped"), 3)
+	if gotResp != resp {
+		t.Fatalf("expected same response pointer to be returned")
+	}
+	if gotErr != nil {
+		t.Fatalf("expected nil error when response is present, got %v", gotErr)
+	}
+}
+
 func TestClient_ResponseLogHook(t *testing.T) {
 	t.Run("ResponseLogHook successfully called with hclog Logger", func(t *testing.T) {
 		buf := new(bytes.Buffer)

--- a/roundtripper_test.go
+++ b/roundtripper_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -131,6 +132,36 @@ func TestRoundTripper_TransportFailureErrorHandling(t *testing.T) {
 	// assert expectations
 	if !reflect.DeepEqual(expectedError, normalizeError(err)) {
 		t.Fatalf("expected %q, got %q", expectedError, err)
+	}
+}
+
+func TestRoundTripper_PassthroughErrorHandlerPreservesResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "test_500_body", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	retryClient := NewClient()
+	retryClient.RetryMax = 0
+	retryClient.ErrorHandler = PassthroughErrorHandler
+
+	client := retryClient.StandardClient()
+	resp, err := client.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("expected nil error when a response is available, got %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+	if !strings.Contains(string(body), "test_500_body") {
+		t.Fatalf("expected response body to be preserved, got %q", body)
 	}
 }
 


### PR DESCRIPTION
## Description

- make `PassthroughErrorHandler` return the terminal `*http.Response` without a competing error when a response exists
- keep `http.Client` / `StandardClient()` callers from silently discarding the final HTTP response on retry exhaustion
- add focused tests for the error handler itself and the `StandardClient` / `RoundTripper` path

## Related Issue

Closes #156

## How Has This Been Tested?

- added unit coverage for `PassthroughErrorHandler`
- added an integration-style test covering `StandardClient()` preserving the final 500 response
