### PR TITLE
fix: avoid panics on typed nil request bodies

### DIFF
--- a/client.go
+++ b/client.go
@@ -35,6 +35,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -205,6 +206,10 @@ func getBodyReaderAndContentLength(rawBody interface{}) (ReaderFunc, int64, erro
 	var bodyReader ReaderFunc
 	var contentLength int64
 
+	if isNilRawBody(rawBody) {
+		return nil, 0, nil
+	}
+
 	switch body := rawBody.(type) {
 	// If they gave us a function already, great! Use it.
 	case ReaderFunc:
@@ -299,6 +304,20 @@ func getBodyReaderAndContentLength(rawBody interface{}) (ReaderFunc, int64, erro
 		return nil, 0, fmt.Errorf("cannot handle type %T", rawBody)
 	}
 	return bodyReader, contentLength, nil
+}
+
+func isNilRawBody(rawBody interface{}) bool {
+	if rawBody == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(rawBody)
+	switch value.Kind() {
+	case reflect.Pointer, reflect.Func:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 // FromRequest wraps an http.Request in a retryablehttp.Request

--- a/client_test.go
+++ b/client_test.go
@@ -733,6 +733,61 @@ func TestClient_NewRequestWithContext(t *testing.T) {
 	}
 }
 
+func TestClient_NewRequestWithContext_TypedNilBody(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name string
+		body interface{}
+	}{
+		{
+			name: "nil bytes buffer",
+			body: (*bytes.Buffer)(nil),
+		},
+		{
+			name: "nil bytes reader",
+			body: (*bytes.Reader)(nil),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := NewRequestWithContext(ctx, http.MethodPost, "/abc", tt.body)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			if r.ContentLength != 0 {
+				t.Fatalf("bad ContentLength: %d", r.ContentLength)
+			}
+			if r.body != nil {
+				t.Fatal("expected typed nil body to behave like no body")
+			}
+
+			body, err := r.BodyBytes()
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if body != nil {
+				t.Fatalf("expected nil body bytes, got %q", string(body))
+			}
+
+			rc, err := r.GetBody()
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			defer rc.Close()
+
+			got, err := io.ReadAll(rc)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if len(got) != 0 {
+				t.Fatalf("expected empty body, got %q", string(got))
+			}
+		})
+	}
+}
+
 func TestClient_RequestWithContext(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)


### PR DESCRIPTION
## Summary
- treat typed nil pointer bodies as no body instead of dereferencing them
- fix the panic reported for `*bytes.Buffer(nil)`
- add focused regression coverage for typed nil `*bytes.Buffer` and `*bytes.Reader` request bodies

## Why
The current `getBodyReaderAndContentLength` type-switch handles concrete pointer body types like `*bytes.Buffer` and `*bytes.Reader`, but it assumes the pointer value is non-nil once the dynamic type matches. That means a typed nil body can panic during request construction instead of behaving like an absent body.

This patch treats typed nil pointer/function bodies the same way as a nil body and keeps the resulting request behavior aligned with the existing no-body path.

Closes #188.
