### PR TITLE
fix: avoid panics on unsupported logger types

### DIFF
--- a/client.go
+++ b/client.go
@@ -432,7 +432,6 @@ type Client struct {
 	// PrepareRetry can prepare the request for retry operation, for example re-sign it
 	PrepareRetry PrepareRetry
 
-	loggerInit sync.Once
 	clientInit sync.Once
 }
 
@@ -450,21 +449,16 @@ func NewClient() *Client {
 }
 
 func (c *Client) logger() interface{} {
-	c.loggerInit.Do(func() {
-		if c.Logger == nil {
-			return
-		}
+	if c.Logger == nil {
+		return nil
+	}
 
-		switch c.Logger.(type) {
-		case Logger, LeveledLogger:
-			// ok
-		default:
-			// This should happen in dev when they are setting Logger and work on code, not in prod.
-			panic(fmt.Sprintf("invalid logger type passed, must be Logger or LeveledLogger, was %T", c.Logger))
-		}
-	})
-
-	return c.Logger
+	switch c.Logger.(type) {
+	case Logger, LeveledLogger:
+		return c.Logger
+	default:
+		return nil
+	}
 }
 
 // DefaultRetryPolicy provides a default callback for Client.CheckRetry, which

--- a/client_test.go
+++ b/client_test.go
@@ -626,6 +626,47 @@ func testClientRequestLogHook(t *testing.T, logger interface{}) {
 	}
 }
 
+func TestClient_InvalidLoggerDoesNotPanic(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	client := NewClient()
+	client.Logger = struct{}{}
+
+	requestLogCalled := false
+	responseLogCalled := false
+	client.RequestLogHook = func(logger Logger, req *http.Request, retry int) {
+		requestLogCalled = true
+		if logger != nil {
+			t.Fatalf("expected nil logger for invalid logger type, got %T", logger)
+		}
+	}
+	client.ResponseLogHook = func(logger Logger, resp *http.Response) {
+		responseLogCalled = true
+		if logger != nil {
+			t.Fatalf("expected nil logger for invalid logger type, got %T", logger)
+		}
+	}
+
+	resp, err := client.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	resp.Body.Close()
+
+	if !requestLogCalled {
+		t.Fatal("request log hook was not called")
+	}
+	if !responseLogCalled {
+		t.Fatal("response log hook was not called")
+	}
+	if _, ok := client.Logger.(struct{}); !ok {
+		t.Fatalf("expected original invalid logger value to remain available, got %T", client.Logger)
+	}
+}
+
 func TestClient_ResponseLogHook(t *testing.T) {
 	t.Run("ResponseLogHook successfully called with hclog Logger", func(t *testing.T) {
 		buf := new(bytes.Buffer)


### PR DESCRIPTION
## Summary
- stop treating unsupported `Client.Logger` values as a runtime panic
- fall back to no-op internal logging when the logger does not implement `Logger` or `LeveledLogger`
- add regression coverage showing requests and log hooks still complete without crashing

## Why
The current `Client.logger()` path panics during request execution when `Client.Logger` is set to an unsupported type. That turns a configuration mistake into a production crash.

This patch keeps the existing supported logger behavior unchanged, but treats unsupported logger values the same way as no logger for internal logging paths. Requests still complete, hooks still run, and applications no longer crash at runtime because of an invalid logger assignment.

Closes #243.
