### PR TITLE
fix: keep response body readable during Backoff

### DIFF
--- a/client.go
+++ b/client.go
@@ -390,6 +390,11 @@ type CheckRetry func(ctx context.Context, resp *http.Response, err error) (bool,
 // Backoff specifies a policy for how long to wait between retries.
 // It is called after a failing request to determine the amount of time
 // that should pass before trying again.
+//
+// When a retry is going to happen, resp.Body is still open while Backoff runs
+// so callers can inspect retry hints carried in the response body. After
+// Backoff returns, the Client drains and closes that body before issuing the
+// next attempt.
 type Backoff func(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration
 
 // ErrorHandler is called if retries are expired, containing the last status
@@ -763,12 +768,12 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 			break
 		}
 
+		wait := c.Backoff(c.RetryWaitMin, c.RetryWaitMax, i, resp)
+
 		// We're going to retry, consume any response to reuse the connection.
 		if doErr == nil {
 			c.drainBody(resp.Body)
 		}
-
-		wait := c.Backoff(c.RetryWaitMin, c.RetryWaitMax, i, resp)
 		if logger != nil {
 			desc := fmt.Sprintf("%s %s", req.Method, redactURL(req.URL))
 			if resp != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -1332,6 +1332,50 @@ func TestClient_BackoffCustom(t *testing.T) {
 	}
 }
 
+func TestClient_BackoffCanReadResponseBody(t *testing.T) {
+	client := NewClient()
+	client.RetryMax = 1
+
+	var calls int32
+	client.CheckRetry = func(_ context.Context, resp *http.Response, err error) (bool, error) {
+		return DefaultRetryPolicy(context.Background(), resp, err)
+	}
+
+	client.Backoff = func(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
+		atomic.AddInt32(&calls, 1)
+
+		if resp == nil {
+			t.Fatal("expected response to be available in Backoff")
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("expected Backoff to read response body, got error: %v", err)
+		}
+
+		if string(body) != "retry-body" {
+			t.Fatalf("expected retry body %q, got %q", "retry-body", string(body))
+		}
+
+		return time.Millisecond
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, "retry-body")
+	}))
+	defer ts.Close()
+
+	_, err := client.Get(ts.URL)
+	if err == nil {
+		t.Fatal("expected retry exhaustion error")
+	}
+
+	if calls != 1 {
+		t.Fatalf("expected Backoff to be called once, got %d", calls)
+	}
+}
+
 func TestClient_StandardClient(t *testing.T) {
 	// Create a retryable HTTP client.
 	client := NewClient()


### PR DESCRIPTION
## Summary

When `Client.Do` decides to retry, it currently drains and closes `resp.Body` **before** invoking `Backoff`. That makes `Backoff` callbacks unable to inspect retry hints carried in the response body and reproduces the `http2: response body closed` problem described in #215.

This change moves the body drain/close step to **after** `Backoff` returns, so custom backoff policies can still read the response body during the callback while the connection reuse behavior stays unchanged for the next attempt.

It also documents that `resp.Body` remains readable while `Backoff` runs and is drained/closed immediately afterwards when a retry will proceed.

Closes #215.

## What changed

- call `Backoff(...)` before `drainBody(resp.Body)` on retry paths
- document the response-body lifetime around `Backoff`
- add focused regression coverage proving `Backoff` can read the retry response body

## Notes

- no exported API changes
- if a `Backoff` callback fully consumes the body, the later drain becomes a no-op and still closes it as before
