### PR TITLE
fix: use default retry hooks for zero-value Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -670,6 +670,16 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 		}
 	})
 
+	checkRetry := c.CheckRetry
+	if checkRetry == nil {
+		checkRetry = DefaultRetryPolicy
+	}
+
+	backoff := c.Backoff
+	if backoff == nil {
+		backoff = DefaultBackoff
+	}
+
 	logger := c.logger()
 
 	if logger != nil {
@@ -719,10 +729,10 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 		resp, doErr = c.HTTPClient.Do(req.Request)
 
 		// Check if we should continue with retries.
-		shouldRetry, checkErr = c.CheckRetry(req.Context(), resp, doErr)
+		shouldRetry, checkErr = checkRetry(req.Context(), resp, doErr)
 		if !shouldRetry && doErr == nil && req.responseHandler != nil {
 			respErr = req.responseHandler(resp)
-			shouldRetry, checkErr = c.CheckRetry(req.Context(), resp, respErr)
+			shouldRetry, checkErr = checkRetry(req.Context(), resp, respErr)
 		}
 
 		err := doErr
@@ -768,7 +778,7 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 			c.drainBody(resp.Body)
 		}
 
-		wait := c.Backoff(c.RetryWaitMin, c.RetryWaitMax, i, resp)
+		wait := backoff(c.RetryWaitMin, c.RetryWaitMax, i, resp)
 		if logger != nil {
 			desc := fmt.Sprintf("%s %s", req.Method, redactURL(req.URL))
 			if resp != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -805,6 +805,31 @@ func TestClient_CheckRetry(t *testing.T) {
 	}
 }
 
+func TestClient_ZeroValueUsesDefaultPolicies(t *testing.T) {
+	var requests int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		http.Error(w, "test_500_body", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	client := &Client{RetryMax: 1}
+
+	_, err := client.Get(ts.URL)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if got := atomic.LoadInt32(&requests); got != 2 {
+		t.Fatalf("expected 2 attempts, got %d", got)
+	}
+
+	if !strings.Contains(err.Error(), "giving up after 2 attempt(s)") {
+		t.Fatalf("expected retry exhaustion error, got: %v", err)
+	}
+}
+
 func testStaticTime(t *testing.T) {
 	timeNow = func() time.Time {
 		now, err := time.Parse(time.RFC1123, "Fri, 31 Dec 1999 23:59:57 GMT")


### PR DESCRIPTION
## Summary
- fall back to `DefaultRetryPolicy` when `Client.CheckRetry` is nil
- fall back to `DefaultBackoff` when `Client.Backoff` is nil
- add regression coverage showing a manually constructed zero-value `Client` no longer panics and still retries

## Why
`NewClient()` initializes these hooks, but the `Client` type is public and issue #108 reports a real panic when callers construct `&retryablehttp.Client{}` directly. This change keeps that usage from crashing in `Do()` while preserving the existing behavior for fully initialized clients.

Closes #108