### PR TITLE
docs: point build status badge at GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 go-retryablehttp
 ================
 
-[![Build Status](http://img.shields.io/travis/hashicorp/go-retryablehttp.svg?style=flat-square)][travis]
+[![Build Status](https://github.com/hashicorp/go-retryablehttp/actions/workflows/pr-unit-tests.yaml/badge.svg)][actions]
 [![Go Documentation](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)][godocs]
 
-[travis]: http://travis-ci.org/hashicorp/go-retryablehttp
+[actions]: https://github.com/hashicorp/go-retryablehttp/actions/workflows/pr-unit-tests.yaml
 [godocs]: http://godoc.org/github.com/hashicorp/go-retryablehttp
 
 The `retryablehttp` package provides a familiar HTTP client interface with


### PR DESCRIPTION
## Summary
- Travis CI is inactive for this repository (badge currently links to a not-active page).
- Unit tests already run via `.github/workflows/pr-unit-tests.yaml`, so the README build badge now points there.

Fixes #233

## Test plan
- [x] Confirm the Actions workflow file exists and is the current CI path
- [x] Confirm the README badge URL resolves to the GitHub Actions workflow page
- [ ] Spot-check the badge on the PR branch README render