### PR TITLE
Cap Retry-After waits to RetryWaitMax in RateLimitLinearJitterBackoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+BUG FIXES:
+
+- client: cap `Retry-After` waits in `RateLimitLinearJitterBackoff` to `RetryWaitMax` (#295)
+
 ## 0.7.7 (May 30, 2024)
 
 BUG FIXES:

--- a/client.go
+++ b/client.go
@@ -642,12 +642,15 @@ func LinearJitterBackoff(min, max time.Duration, attemptNum int, resp *http.Resp
 // It first checks if the response status code is http.StatusTooManyRequests
 // (HTTP Code 429) or http.StatusServiceUnavailable (HTTP Code 503). If it is
 // and the response contains a Retry-After response header, it will wait the
-// amount of time specified by the header. Otherwise, this calls
+// amount of time specified by the header, capped by max. Otherwise, this calls
 // LinearJitterBackoff.
 func RateLimitLinearJitterBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
 	if resp != nil {
 		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
 			if sleep, ok := parseRetryAfterHeader(resp.Header["Retry-After"]); ok {
+				if sleep > max {
+					return max
+				}
 				return sleep
 			}
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -1176,7 +1176,7 @@ func TestBackoff_RateLimitLinearJitterBackoff(t *testing.T) {
 				"Retry-After": []string{"2"},
 			},
 			responseCode: http.StatusTooManyRequests,
-			expect:       2 * time.Second,
+			expect:       time.Second,
 		},
 		{
 			name: "503 retry header",
@@ -1186,7 +1186,17 @@ func TestBackoff_RateLimitLinearJitterBackoff(t *testing.T) {
 				"Retry-After": []string{"2"},
 			},
 			responseCode: http.StatusServiceUnavailable,
-			expect:       2 * time.Second,
+			expect:       time.Second,
+		},
+		{
+			name: "429 retry header greater than max",
+			min:  time.Second,
+			max:  3 * time.Second,
+			headers: http.Header{
+				"Retry-After": []string{"3600"},
+			},
+			responseCode: http.StatusTooManyRequests,
+			expect:       3 * time.Second,
 		},
 		{
 			name: "502 ignore retry header",


### PR DESCRIPTION
## Description

`RateLimitLinearJitterBackoff` treated `Retry-After` as an uncapped sleep. A 429 or 503 with a large `Retry-After` (or a far-future HTTP-date) could stall the client longer than `RetryWaitMax`.

This caps that wait to `max`, which is the value callers already pass from `Client.RetryWaitMax`. `DefaultBackoff` is left unchanged because #283 already covers that helper.

## Related Issue

Fixes #295

## How Has This Been Tested?

- `go test ./...`
- `go test -count=1 -run TestBackoff_RateLimitLinearJitterBackoff .`

Existing cases where `Retry-After` was larger than `max` now expect the cap. Added a 3600s `Retry-After` case with `max` of 3s.