### PR TITLE
Reject a Retry-After that overflows the Duration conversion

### DIFF
--- a/client.go
+++ b/client.go
@@ -585,6 +585,14 @@ func parseRetryAfterHeader(headers []string) (time.Duration, bool) {
 		if sleep < 0 { // a negative sleep doesn't make sense
 			return 0, false
 		}
+		// A Duration counts nanoseconds, so seconds beyond this overflow it and
+		// wrap to a negative value. time.NewTimer fires immediately on a
+		// negative duration, which would turn an absurd Retry-After into no
+		// wait at all -- the opposite of backing off. Treat it as unparseable
+		// so the caller falls back to its normal backoff.
+		if sleep > int64(math.MaxInt64/time.Second) {
+			return 0, false
+		}
 		return time.Second * time.Duration(sleep), true
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -833,6 +833,13 @@ func TestParseRetryAfterHeader(t *testing.T) {
 		{"two-headers", []string{"2", "3"}, time.Second * 2, true},
 		{"empty", []string{""}, 0, false},
 		{"negative", []string{"-2"}, 0, false},
+		// A seconds value large enough to overflow the nanosecond conversion
+		// used to wrap to a negative Duration, and a negative wait makes
+		// time.NewTimer fire at once -- the client then retried with no delay
+		// at all, which is the opposite of backing off.
+		{"seconds-overflow", []string{"9223372037"}, 0, false},
+		{"seconds-overflow-max-int64", []string{"9223372036854775807"}, 0, false},
+		{"seconds-largest-representable", []string{"9223372036"}, time.Second * 9223372036, true},
 		{"bad-date", []string{"Fri, 32 Dec 1999 23:59:59 GMT"}, 0, false},
 		{"bad-date-format", []string{"badbadbad"}, 0, false},
 	}


### PR DESCRIPTION
## Description

`parseRetryAfterHeader` converts a seconds value with `time.Second * time.Duration(sleep)`. A `Duration` counts nanoseconds, so any value above `math.MaxInt64/time.Second` (9223372036, about 292 years) wraps and comes back **negative**:

```
Retry-After: 120                    -> 2m0s                       ok=true
Retry-After: 9223372036             -> 2562047h47m16s             ok=true
Retry-After: 9223372037             -> -2562047h47m16s            ok=true   <-- negative
Retry-After: 9223372036854775807    -> -1s                        ok=true   <-- negative
```

The header is reported as successfully parsed, so `DefaultBackoff` and `RateLimitLinearJitterBackoff` hand that negative duration back as the wait. `client.go:784` does:

```go
timer := time.NewTimer(wait)
```

**A negative duration makes the timer fire immediately.** The client retries with no delay and keeps doing so until `RetryMax` is spent — so a server asking to be left alone for a long time is answered with a burst of requests instead. That is the opposite of what the header, and this library, are for.

The existing guard covers a negative value *in the header*:

```go
if sleep < 0 { // a negative sleep doesn't make sense
    return 0, false
}
```

but not a positive value that *becomes* negative in the conversion.

## Related Issue

None open that I could find; noticed while reading the backoff paths.

## How Has This Been Tested?

Three cases added to the existing `TestParseRetryAfterHeader` table:

| Case | Header | Expected |
|---|---|---|
| `seconds-overflow` | `9223372037` | not parseable |
| `seconds-overflow-max-int64` | `9223372036854775807` | not parseable |
| `seconds-largest-representable` | `9223372036` | `9223372036s`, parseable |

The third pins the boundary so the guard cannot be tightened by accident and start rejecting valid values.

Values past the representable range are treated as unparseable, so the caller falls back to its usual exponential backoff — the same thing that already happens for an empty, malformed or date-in-the-past header. Clamping to `MaxInt64` instead would mean a ~292 year wait, which seemed worse than ignoring an absurd header.

`go test ./...` passes (22.8s). Removing the guard fails the two overflow cases and leaves the boundary case passing.

Go 1.23.4, Linux.