### PR TITLE
client: cap RateLimitLinearJitterBackoff Retry-After waits at max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+BUG FIXES:
+
+- client: cap `Retry-After` waits in `RateLimitLinearJitterBackoff` at `RetryWaitMax`
+
 ## 0.7.7 (May 30, 2024)
 
 BUG FIXES:

--- a/client.go
+++ b/client.go
@@ -638,16 +638,17 @@ func LinearJitterBackoff(min, max time.Duration, attemptNum int, resp *http.Resp
 	return time.Duration(jitterMin * int64(attemptNum))
 }
 
-// RateLimitLinearJitterBackoff wraps the retryablehttp.LinearJitterBackoff.
-// It first checks if the response status code is http.StatusTooManyRequests
-// (HTTP Code 429) or http.StatusServiceUnavailable (HTTP Code 503). If it is
-// and the response contains a Retry-After response header, it will wait the
-// amount of time specified by the header. Otherwise, this calls
+// RateLimitLinearJitterBackoff wraps LinearJitterBackoff.
+// If the response is 429 or 503 and includes a Retry-After header, it waits
+// for that duration, capped at max (RetryWaitMax). Otherwise it uses
 // LinearJitterBackoff.
 func RateLimitLinearJitterBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
 	if resp != nil {
 		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
 			if sleep, ok := parseRetryAfterHeader(resp.Header["Retry-After"]); ok {
+				if sleep > max {
+					return max
+				}
 				return sleep
 			}
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -1176,7 +1176,7 @@ func TestBackoff_RateLimitLinearJitterBackoff(t *testing.T) {
 				"Retry-After": []string{"2"},
 			},
 			responseCode: http.StatusTooManyRequests,
-			expect:       2 * time.Second,
+			expect:       time.Second,
 		},
 		{
 			name: "503 retry header",
@@ -1186,7 +1186,27 @@ func TestBackoff_RateLimitLinearJitterBackoff(t *testing.T) {
 				"Retry-After": []string{"2"},
 			},
 			responseCode: http.StatusServiceUnavailable,
-			expect:       2 * time.Second,
+			expect:       time.Second,
+		},
+		{
+			name: "429 retry header larger than max",
+			min:  time.Second,
+			max:  3 * time.Second,
+			headers: http.Header{
+				"Retry-After": []string{"3600"},
+			},
+			responseCode: http.StatusTooManyRequests,
+			expect:       3 * time.Second,
+		},
+		{
+			name: "503 retry header larger than max",
+			min:  time.Second,
+			max:  3 * time.Second,
+			headers: http.Header{
+				"Retry-After": []string{"3600"},
+			},
+			responseCode: http.StatusServiceUnavailable,
+			expect:       3 * time.Second,
 		},
 		{
 			name: "502 ignore retry header",


### PR DESCRIPTION
## Description

`RateLimitLinearJitterBackoff` returned a parsed `Retry-After` duration without applying `max` (`RetryWaitMax`). A 429 or 503 with `Retry-After: 3600` (or a far-future HTTP-date) could stall the client for that whole interval even when the caller set a much smaller ceiling.

The exponential path in `DefaultBackoff` already treats `max` as a hard cap. This change does the same for the rate-limit helper: if `Retry-After` is larger than `max`, wait `max` instead. Values at or below `max` are unchanged.

`DefaultBackoff` is left alone; #247 / #283 cover that helper.

## Related Issue

Fixes #295

## How Has This Been Tested?

Fail-then-pass on `TestBackoff_RateLimitLinearJitterBackoff`:

- Before the code change, cases with `Retry-After` greater than `max` failed (`expected 1s, got 2s` and `expected 3s, got 1h0m0s`).
- After the cap, those cases pass. Existing in-range `Retry-After` cases still pass.

Also ran:

```
go test -count=1 -run TestBackoff_RateLimitLinearJitterBackoff .
ok

go test -count=1 -race .
ok
```